### PR TITLE
Feature/hardware ids

### DIFF
--- a/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
@@ -18,11 +18,13 @@ package org.jclouds.vcloud.director.v1_5;
 
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.reflect.Reflection2.typeToken;
+import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU;
+import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM;
+import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_TIMEOUT_TASK_COMPLETED;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_VERSION_SCHEMA;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_XML_NAMESPACE;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_XML_SCHEMA;
-
 import java.net.URI;
 import java.util.Properties;
 
@@ -65,6 +67,10 @@ public class VCloudDirectorApiMetadata extends BaseHttpApiMetadata<VCloudDirecto
       // TODO integrate these with the {@link ComputeTimeouts} instead of having a single timeout for everything.
       properties.setProperty(PROPERTY_SESSION_INTERVAL, Integer.toString(300));
       properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_TIMEOUT_TASK_COMPLETED, Long.toString(1200l * 1000l));
+
+      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU, "" + 8);
+      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM, "" + 512);
+      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM, "" + 1024 * 8);
 
       return properties;
    }

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorConstants.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorConstants.java
@@ -45,6 +45,21 @@ public final class VCloudDirectorConstants {
    /** TODO javadoc */
    public static final String PROPERTY_NS_NAME_LEN_MAX = "jclouds.dns_name_length_max";
 
+   /**
+    * For synthesizing hardware profiles, the maximum number of CPUs.
+    */
+   public static final String PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU = "jclouds.vcloud-director.hardware-profiles.max-cpu";
+
+   /**
+    * For synthesizing hardware profiles, the minimum megabytes of RAM.
+    */
+   public static final String PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM = "jclouds.vcloud-director.hardware-profiles.min-ram";
+
+   /**
+    * For synthesizing hardware profiles, the maximum megabytes of RAM.
+    */
+   public static final String PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM = "jclouds.vcloud-director.hardware-profiles.max-ram";
+
    /** TODO javadoc */
    /*
    public static final TypeToken<RestContext<SessionApi, SessionAsyncApi>> SESSION_CONTEXT_TYPE =

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/config/VCloudDirectorComputeServiceContextModule.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/config/VCloudDirectorComputeServiceContextModule.java
@@ -18,6 +18,7 @@ package org.jclouds.vcloud.director.v1_5.compute.config;
 
 import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import java.net.URI;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.jclouds.compute.ComputeServiceAdapter;
@@ -37,6 +38,7 @@ import org.jclouds.vcloud.director.v1_5.compute.functions.ImageStateForStatus;
 import org.jclouds.vcloud.director.v1_5.compute.functions.NodemetadataStatusForStatus;
 import org.jclouds.vcloud.director.v1_5.compute.functions.ValidateVAppTemplateAndReturnEnvelopeOrThrowIllegalArgumentException;
 import org.jclouds.vcloud.director.v1_5.compute.functions.VdcToLocation;
+import org.jclouds.vcloud.director.v1_5.compute.suppliers.VirtualHardwareConfigSupplier;
 import org.jclouds.vcloud.director.v1_5.compute.functions.VmToNodeMetadata;
 import org.jclouds.vcloud.director.v1_5.compute.options.VCloudDirectorTemplateOptions;
 import org.jclouds.vcloud.director.v1_5.compute.strategy.VCloudDirectorComputeServiceAdapter;
@@ -88,13 +90,9 @@ public class VCloudDirectorComputeServiceContextModule extends
       bind(new TypeLiteral<Function<Vdc, Location>>() {
       }).to(VdcToLocation.class);
       bind(TemplateOptions.class).to(VCloudDirectorTemplateOptions.class);
+      bind(new TypeLiteral<Supplier<Set<Hardware>>>() {}).to(VirtualHardwareConfigSupplier.class);
       install(new LocationsFromComputeServiceAdapterModule<Vm, Hardware, VAppTemplate, Vdc>() {
       });
-
-      /*
-      bind(new TypeLiteral<Function<Reference, Location>>() {
-      }).to(Class.class.cast(FindLocationForResource.class));
-      */
    }
 
    @Provides

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/HardwareForVm.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/HardwareForVm.java
@@ -76,7 +76,7 @@ public class HardwareForVm implements Function<Vm, Hardware> {
       double cores = extractCoresFrom(virtualHardwareSection);
       builder.id(from.getId())
              .name(from.getName())
-             .hypervisor("VMware")
+             .hypervisor("esxi")
              .providerId(from.getHref().toString())
              .ram(ram)
              .processors(ImmutableList.of(new Processor(cores, 1)));

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/options/VCloudDirectorTemplateOptions.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/options/VCloudDirectorTemplateOptions.java
@@ -17,35 +17,54 @@
 package org.jclouds.vcloud.director.v1_5.compute.options;
 
 import static com.google.common.base.Objects.equal;
-
-import com.google.common.base.Objects;
+import java.util.Map;
 
 import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.domain.LoginCredentials;
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.scriptbuilder.domain.Statement;
 import org.jclouds.scriptbuilder.domain.Statements;
 
+import com.google.common.base.Objects;
+
 public class VCloudDirectorTemplateOptions extends TemplateOptions implements Cloneable {
 
-   private Statement guestCustomizationScript = null;
+   protected Statement guestCustomizationScript;
+   protected Integer memory;
+   protected Integer virtualCpus;
 
    /**
     * Specifies a script to be added to the GuestCustomizationSection
     */
-   public VCloudDirectorTemplateOptions guestCustomizationScript(String guestCustomizationScript) {
+   public VCloudDirectorTemplateOptions guestCustomizationScript(@Nullable String guestCustomizationScript) {
       return guestCustomizationScript(Statements.exec(guestCustomizationScript));
    }
 
    /**
     * Specifies a script to be added to the GuestCustomizationSection
     */
-   public VCloudDirectorTemplateOptions guestCustomizationScript(Statement guestCustomizationScript) {
+   public VCloudDirectorTemplateOptions guestCustomizationScript(@Nullable Statement guestCustomizationScript) {
       this.guestCustomizationScript = guestCustomizationScript;
+      return this;
+   }
+
+   public VCloudDirectorTemplateOptions memory(@Nullable Integer memory) {
+      this.memory = memory;
+      return this;
+   }
+
+   public VCloudDirectorTemplateOptions virtualCpus(@Nullable Integer virtualCpus) {
+      this.virtualCpus = virtualCpus;
       return this;
    }
 
    public Statement getGuestCustomizationScript() {
       return guestCustomizationScript;
    }
+
+   public Integer getMemory() { return memory; }
+
+   public Integer getVirtualCpus() { return virtualCpus; }
 
    @Override
    public VCloudDirectorTemplateOptions clone() {
@@ -59,8 +78,9 @@ public class VCloudDirectorTemplateOptions extends TemplateOptions implements Cl
       super.copyTo(to);
       if (to instanceof VCloudDirectorTemplateOptions) {
          VCloudDirectorTemplateOptions vto = VCloudDirectorTemplateOptions.class.cast(to);
-         if (getGuestCustomizationScript() != null)
-            vto.guestCustomizationScript(getGuestCustomizationScript());
+         vto.guestCustomizationScript(getGuestCustomizationScript());
+         vto.memory(memory);
+         vto.virtualCpus(virtualCpus);
       }
    }
 
@@ -87,10 +107,11 @@ public class VCloudDirectorTemplateOptions extends TemplateOptions implements Cl
       return toString;
    }
 
-   /**
-    * @see VCloudDirectorTemplateOptions#guestCustomizationScript
-    */
-   public static class Builder extends TemplateOptions.Builder {
+   public static class Builder {
+
+      /**
+       * @see #guestCustomizationScript
+       */
       public static VCloudDirectorTemplateOptions guestCustomizationScript(String guestCustomizationScript) {
          return guestCustomizationScript(Statements.exec(guestCustomizationScript));
       }
@@ -99,5 +120,274 @@ public class VCloudDirectorTemplateOptions extends TemplateOptions implements Cl
          VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
          return options.guestCustomizationScript(guestCustomizationScript);
       }
+
+      /**
+       * @see #memory
+       */
+      public static VCloudDirectorTemplateOptions memory(Integer memory) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.memory(memory);
+      }
+
+      /**
+       * @see #virtualCpus
+       */
+      public static VCloudDirectorTemplateOptions virtualCpus(Integer virtualCpus) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.virtualCpus(virtualCpus);
+      }
+
+      /**
+       * @see TemplateOptions#inboundPorts(int...)
+       */
+      public static VCloudDirectorTemplateOptions inboundPorts(int... ports) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.inboundPorts(ports);
+      }
+
+      /**
+       * @see TemplateOptions#blockOnPort(int, int)
+       */
+      public static VCloudDirectorTemplateOptions blockOnPort(int port, int seconds) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.blockOnPort(port, seconds);
+      }
+
+      /**
+       * @see TemplateOptions#installPrivateKey(String)
+       */
+      public static VCloudDirectorTemplateOptions installPrivateKey(String rsaKey) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.installPrivateKey(rsaKey);
+      }
+
+      /**
+       * @see TemplateOptions#authorizePublicKey(String)
+       */
+      public static VCloudDirectorTemplateOptions authorizePublicKey(String rsaKey) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.authorizePublicKey(rsaKey);
+      }
+
+      /**
+       * @see TemplateOptions#userMetadata(Map)
+       */
+      public static VCloudDirectorTemplateOptions userMetadata(Map<String, String> userMetadata) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.userMetadata(userMetadata);
+      }
+
+      /**
+       * @see TemplateOptions#nodeNames(Iterable)
+       */
+      public static VCloudDirectorTemplateOptions nodeNames(Iterable<String> nodeNames) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.nodeNames(nodeNames);
+      }
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static VCloudDirectorTemplateOptions networks(Iterable<String> networks) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.networks(networks);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginUser(String)
+       */
+      public static VCloudDirectorTemplateOptions overrideLoginUser(String user) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.overrideLoginUser(user);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginPassword(String)
+       */
+      public static VCloudDirectorTemplateOptions overrideLoginPassword(String password) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.overrideLoginPassword(password);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginPrivateKey(String)
+       */
+      public static VCloudDirectorTemplateOptions overrideLoginPrivateKey(String privateKey) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.overrideLoginPrivateKey(privateKey);
+      }
+
+      /**
+       * @see TemplateOptions#overrideAuthenticateSudo(boolean)
+       */
+      public static VCloudDirectorTemplateOptions overrideAuthenticateSudo(boolean authenticateSudo) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.overrideAuthenticateSudo(authenticateSudo);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginCredentials(LoginCredentials)
+       */
+      public static VCloudDirectorTemplateOptions overrideLoginCredentials(LoginCredentials credentials) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.overrideLoginCredentials(credentials);
+      }
+
+      /**
+       * @see TemplateOptions#blockUntilRunning(boolean)
+       */
+      public static VCloudDirectorTemplateOptions blockUntilRunning(boolean blockUntilRunning) {
+         VCloudDirectorTemplateOptions options = new VCloudDirectorTemplateOptions();
+         return options.blockUntilRunning(blockUntilRunning);
+      }
+
    }
+
+
+   // methods that only facilitate returning the correct object type
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions blockOnPort(int port, int seconds) {
+      return VCloudDirectorTemplateOptions.class.cast(super.blockOnPort(port, seconds));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions inboundPorts(int... ports) {
+      return VCloudDirectorTemplateOptions.class.cast(super.inboundPorts(ports));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions authorizePublicKey(String publicKey) {
+      return VCloudDirectorTemplateOptions.class.cast(super.authorizePublicKey(publicKey));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions installPrivateKey(String privateKey) {
+      return VCloudDirectorTemplateOptions.class.cast(super.installPrivateKey(privateKey));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions blockUntilRunning(boolean blockUntilRunning) {
+      return VCloudDirectorTemplateOptions.class.cast(super.blockUntilRunning(blockUntilRunning));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions dontAuthorizePublicKey() {
+      return VCloudDirectorTemplateOptions.class.cast(super.dontAuthorizePublicKey());
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions nameTask(String name) {
+      return VCloudDirectorTemplateOptions.class.cast(super.nameTask(name));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions runAsRoot(boolean runAsRoot) {
+      return VCloudDirectorTemplateOptions.class.cast(super.runAsRoot(runAsRoot));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions runScript(Statement script) {
+      return VCloudDirectorTemplateOptions.class.cast(super.runScript(script));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions overrideLoginCredentials(LoginCredentials overridingCredentials) {
+      return VCloudDirectorTemplateOptions.class.cast(super.overrideLoginCredentials(overridingCredentials));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions overrideLoginPassword(String password) {
+      return VCloudDirectorTemplateOptions.class.cast(super.overrideLoginPassword(password));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions overrideLoginPrivateKey(String privateKey) {
+      return VCloudDirectorTemplateOptions.class.cast(super.overrideLoginPrivateKey(privateKey));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions overrideLoginUser(String loginUser) {
+      return VCloudDirectorTemplateOptions.class.cast(super.overrideLoginUser(loginUser));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions overrideAuthenticateSudo(boolean authenticateSudo) {
+      return VCloudDirectorTemplateOptions.class.cast(super.overrideAuthenticateSudo(authenticateSudo));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions userMetadata(Map<String, String> userMetadata) {
+      return VCloudDirectorTemplateOptions.class.cast(super.userMetadata(userMetadata));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions userMetadata(String key, String value) {
+      return VCloudDirectorTemplateOptions.class.cast(super.userMetadata(key, value));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions nodeNames(Iterable<String> nodeNames) {
+      return VCloudDirectorTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public VCloudDirectorTemplateOptions networks(Iterable<String> networks) {
+      return VCloudDirectorTemplateOptions.class.cast(super.networks(networks));
+   }
+
 }

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapter.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapter.java
@@ -25,7 +25,9 @@ import static org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType.VAPP_TEMP
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType.VDC;
 import static org.jclouds.vcloud.director.v1_5.compute.util.VCloudDirectorComputeUtils.name;
 import static org.jclouds.vcloud.director.v1_5.compute.util.VCloudDirectorComputeUtils.tryFindNetworkInVDCWithFenceMode;
+import java.math.BigInteger;
 import java.net.URI;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Resource;
@@ -35,7 +37,6 @@ import javax.inject.Singleton;
 
 import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.domain.Hardware;
-import org.jclouds.compute.domain.HardwareBuilder;
 import org.jclouds.compute.domain.Processor;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.reference.ComputeServiceConstants;
@@ -55,6 +56,7 @@ import org.jclouds.vcloud.director.v1_5.domain.VApp;
 import org.jclouds.vcloud.director.v1_5.domain.VAppTemplate;
 import org.jclouds.vcloud.director.v1_5.domain.Vdc;
 import org.jclouds.vcloud.director.v1_5.domain.Vm;
+import org.jclouds.vcloud.director.v1_5.domain.dmtf.cim.ResourceAllocationSettingData;
 import org.jclouds.vcloud.director.v1_5.domain.dmtf.ovf.MsgType;
 import org.jclouds.vcloud.director.v1_5.domain.network.Network;
 import org.jclouds.vcloud.director.v1_5.domain.network.NetworkAssignment;
@@ -63,12 +65,14 @@ import org.jclouds.vcloud.director.v1_5.domain.network.NetworkConnection;
 import org.jclouds.vcloud.director.v1_5.domain.network.VAppNetworkConfiguration;
 import org.jclouds.vcloud.director.v1_5.domain.org.Org;
 import org.jclouds.vcloud.director.v1_5.domain.params.ComposeVAppParams;
+import org.jclouds.vcloud.director.v1_5.domain.params.DeployVAppParams;
 import org.jclouds.vcloud.director.v1_5.domain.params.InstantiationParams;
 import org.jclouds.vcloud.director.v1_5.domain.params.SourcedCompositionItemParam;
 import org.jclouds.vcloud.director.v1_5.domain.params.UndeployVAppParams;
 import org.jclouds.vcloud.director.v1_5.domain.section.GuestCustomizationSection;
 import org.jclouds.vcloud.director.v1_5.domain.section.NetworkConfigSection;
 import org.jclouds.vcloud.director.v1_5.domain.section.NetworkConnectionSection;
+import org.jclouds.vcloud.director.v1_5.domain.section.VirtualHardwareSection;
 import org.jclouds.vcloud.director.v1_5.predicates.ReferencePredicates;
 import org.jclouds.vcloud.director.v1_5.predicates.TaskSuccess;
 
@@ -76,6 +80,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -98,11 +103,13 @@ public class VCloudDirectorComputeServiceAdapter implements
 
    private final VCloudDirectorApi api;
    private Predicate<Task> retryTaskSuccess;
+   private final Supplier<Set<Hardware>> hardwareProfileSupplier;
 
    @Inject
-   public VCloudDirectorComputeServiceAdapter(VCloudDirectorApi api) {
+   public VCloudDirectorComputeServiceAdapter(VCloudDirectorApi api, Supplier<Set<Hardware>> hardwareProfileSupplier) {
       this.api = checkNotNull(api, "api");
       retryTaskSuccess = retry(new TaskSuccess(api.getTaskApi()), TASK_TIMEOUT_SECONDS * 1000L);
+      this.hardwareProfileSupplier = hardwareProfileSupplier;
    }
 
    @Override
@@ -112,6 +119,10 @@ public class VCloudDirectorComputeServiceAdapter implements
 
       String imageId = checkNotNull(template.getImage().getId(), "template image id must not be null");
       String locationId = checkNotNull(template.getLocation().getId(), "template location id must not be null");
+      final String hardwareId = checkNotNull(template.getHardware().getId(), "template image id must not be null");
+
+      VCloudDirectorTemplateOptions templateOptions = VCloudDirectorTemplateOptions.class.cast(template.getOptions());
+
       Vdc vdc = getVdc(locationId);
 
       final Reference networkReference;
@@ -142,7 +153,6 @@ public class VCloudDirectorComputeServiceAdapter implements
               .build();
 
       Statement guestCustomizationScript = ((VCloudDirectorTemplateOptions)(template.getOptions())).getGuestCustomizationScript();
-
       if (guestCustomizationScript != null) {
          guestCustomizationSection = guestCustomizationSection.toBuilder()
                  // TODO differentiate on guestOS
@@ -154,8 +164,6 @@ public class VCloudDirectorComputeServiceAdapter implements
               .name(name)
               .instantiationParams(instantiationParams(vdc, networkReference))
               .sourcedItems(ImmutableList.of(vmItem))
-              .deploy()
-              .powerOn()
               .build();
       VApp vApp = api.getVdcApi().composeVApp(vdc.getId(), compositionParams);
       Task compositionTask = Iterables.getFirst(vApp.getTasks(), null);
@@ -166,13 +174,57 @@ public class VCloudDirectorComputeServiceAdapter implements
 
       if (!vApp.getTasks().isEmpty()) {
          for (Task task : vApp.getTasks()) {
+            logger.debug(">> awaiting vApp(%s) composition", vApp.getId());
+            boolean vAppReady = retryTaskSuccess.apply(task);
+            logger.trace("<< vApp(%s) composition completed(%s)", vApp.getId(), vAppReady);
+         }
+      }
+      Vm vm = Iterables.getOnlyElement(api.getVAppApi().get(vApp.getHref()).getChildren().getVms());
 
-            logger.debug(">> awaiting vApp(%s) deployment", vApp.getId());
+      if (!vm.getTasks().isEmpty()) {
+         for (Task task : vm.getTasks()) {
+            logger.debug(">> awaiting vm(%s) deployment", vApp.getId());
             boolean vmReady = retryTaskSuccess.apply(task);
             logger.trace("<< vApp(%s) deployment completed(%s)", vApp.getId(), vmReady);
          }
       }
-      Vm vm = Iterables.getOnlyElement(api.getVAppApi().get(vApp.getHref()).getChildren().getVms());
+
+      // Configure VirtualHardware on a VM
+      Optional<Hardware> hardwareOptional = Iterables.tryFind(listHardwareProfiles(), new Predicate<Hardware>() {
+         @Override
+         public boolean apply(Hardware input) {
+            return input.getId().equals(hardwareId);
+         }
+      });
+
+      // virtualCpus and memory templateOptions get the precedence over the default values given by hardwareId
+      Integer virtualCpus = templateOptions.getVirtualCpus() == null ? getCoresFromHardware(hardwareOptional) : templateOptions.getVirtualCpus();
+      Integer ram = templateOptions.getMemory() == null ? getRamFromHardware(hardwareOptional) : templateOptions.getMemory();
+
+      if (virtualCpus == null || ram == null) {
+         logger.error("the hardwareId %s specified doesn't exist. The deployment may fail subsequently");
+         throw new IllegalStateException("VirtualCPUs and/or ram are null.");
+      }
+
+      VirtualHardwareSection virtualHardwareSection = api.getVmApi().getVirtualHardwareSection(vm.getHref());
+
+      Predicate<ResourceAllocationSettingData> processorPredicate = resourceTypeEquals(ResourceAllocationSettingData.ResourceType.PROCESSOR);
+      virtualHardwareSection = updateVirtualHardwareSection(virtualHardwareSection, processorPredicate, virtualCpus + " virtual CPU(s)", BigInteger.valueOf(virtualCpus.intValue()));
+      Predicate<ResourceAllocationSettingData> memoryPredicate = resourceTypeEquals(ResourceAllocationSettingData.ResourceType.MEMORY);
+      virtualHardwareSection = updateVirtualHardwareSection(virtualHardwareSection, memoryPredicate, ram + " MB of memory", BigInteger.valueOf(ram.intValue()));
+
+      // NOTE this is not efficient but the vCD API v1.5 don't support editing hardware sections during provisioning
+      Task editVirtualHardwareSectionTask = api.getVmApi().editVirtualHardwareSection(vm.getHref(), virtualHardwareSection);
+      logger.debug(">> awaiting vm(%s) to be edited", vm.getId());
+      boolean vmEdited = retryTaskSuccess.apply(editVirtualHardwareSectionTask);
+      logger.trace("<< vApp(%s) to be edited completed(%s)", vm.getId(), vmEdited);
+
+      Task deployTask = api.getVAppApi().deploy(vApp.getHref(), DeployVAppParams.builder()
+              .powerOn()
+              .build());
+      logger.debug(">> awaiting vApp(%s) to be powered on", vApp.getId());
+      boolean vAppPoweredOn = retryTaskSuccess.apply(deployTask);
+      logger.trace("<< vApp(%s) to be powered on completed(%s)", vApp.getId(), vAppPoweredOn);
 
       // Infer the login credentials from the VM, defaulting to "root" user
       LoginCredentials defaultCredentials = VCloudDirectorComputeUtils.getCredentialsFrom(vm);
@@ -201,6 +253,38 @@ public class VCloudDirectorComputeServiceAdapter implements
       return new NodeAndInitialCredentials<Vm>(vm, vm.getId(), credsBuilder.build());
    }
 
+   private VirtualHardwareSection updateVirtualHardwareSection(VirtualHardwareSection virtualHardwareSection, Predicate<ResourceAllocationSettingData>
+           predicate, String elementName, BigInteger virtualQuantity) {
+      Set<? extends ResourceAllocationSettingData> oldItems = virtualHardwareSection.getItems();
+      Set<ResourceAllocationSettingData> newItems = Sets.newLinkedHashSet(oldItems);
+      ResourceAllocationSettingData oldResourceAllocationSettingData = Iterables.find(oldItems, predicate);
+      ResourceAllocationSettingData newResourceAllocationSettingData = oldResourceAllocationSettingData.toBuilder().elementName(elementName).virtualQuantity(virtualQuantity).build();
+      newItems.remove(oldResourceAllocationSettingData);
+      newItems.add(newResourceAllocationSettingData);
+      return virtualHardwareSection.toBuilder().items(newItems).build();
+   }
+
+   private Predicate<ResourceAllocationSettingData> resourceTypeEquals(final ResourceAllocationSettingData.ResourceType resourceType) {
+      return new Predicate<ResourceAllocationSettingData>() {
+         @Override
+         public boolean apply(ResourceAllocationSettingData rasd) {
+            return rasd.getResourceType() == resourceType;
+         }
+      };
+   }
+
+   private Integer getCoresFromHardware(Optional<Hardware> hardwareOptional) {
+      if (!hardwareOptional.isPresent()) return null;
+      List<? extends Processor> processors = hardwareOptional.get().getProcessors();
+      if (processors == null) return null;
+      return Integer.valueOf((int) Iterables.getOnlyElement(processors).getCores());
+   }
+
+   private Integer getRamFromHardware(Optional<Hardware> hardwareOptional) {
+      if (!hardwareOptional.isPresent()) return null;
+      return hardwareOptional.get().getRam();
+   }
+
    private Reference tryFindNetworkInVDC(Vdc vdc, String networkName) {
       Optional<Reference> referenceOptional = Iterables.tryFind(vdc.getAvailableNetworks(), ReferencePredicates.nameEquals(networkName));
       if (!referenceOptional.isPresent()) {
@@ -212,8 +296,8 @@ public class VCloudDirectorComputeServiceAdapter implements
 
    private SourcedCompositionItemParam createVmItem(Vm vm, String networkName, GuestCustomizationSection guestCustomizationSection) {
       // creating an item element. this item will contain the vm which should be added to the vapp.
-      Reference reference = Reference.builder().name(name("vm-")).href(vm.getHref()).type(vm.getType()).build();
-      SourcedCompositionItemParam vmItem = SourcedCompositionItemParam.builder().source(reference).build();
+      final String name = name("vm-");
+      Reference reference = Reference.builder().name(name).href(vm.getHref()).type(vm.getType()).build();
 
       InstantiationParams vmInstantiationParams;
       Set<NetworkAssignment> networkAssignments = Sets.newLinkedHashSet();
@@ -228,26 +312,28 @@ public class VCloudDirectorComputeServiceAdapter implements
               .info(MsgType.builder().value("networkInfo").build())
               .primaryNetworkConnectionIndex(0).networkConnection(networkConnection).build();
 
-      // adding the network connection section to the instantiation params of the vapp.
       vmInstantiationParams = InstantiationParams.builder()
               .sections(ImmutableSet.of(networkConnectionSection, guestCustomizationSection))
               .build();
 
+      SourcedCompositionItemParam.Builder vmItemBuilder = SourcedCompositionItemParam.builder().source(reference);
+
       if (vmInstantiationParams != null)
-         vmItem = SourcedCompositionItemParam.builder().fromSourcedCompositionItemParam(vmItem)
-                 .instantiationParams(vmInstantiationParams).build();
+         vmItemBuilder.instantiationParams(vmInstantiationParams);
 
       if (networkAssignments != null)
-         vmItem = SourcedCompositionItemParam.builder().fromSourcedCompositionItemParam(vmItem)
-                 .networkAssignment(networkAssignments).build();
-      return vmItem;
+         vmItemBuilder.networkAssignment(networkAssignments);
+
+      return vmItemBuilder.build();
    }
 
    protected InstantiationParams instantiationParams(Vdc vdc, Reference network) {
       NetworkConfiguration networkConfiguration = networkConfiguration(vdc, network);
 
       InstantiationParams instantiationParams = InstantiationParams.builder()
-              .sections(ImmutableSet.of(networkConfigSection(network.getName(), networkConfiguration)))
+              .sections(ImmutableSet.of(
+                      networkConfigSection(network.getName(), networkConfiguration))
+              )
               .build();
 
       return instantiationParams;
@@ -289,13 +375,7 @@ public class VCloudDirectorComputeServiceAdapter implements
 
    @Override
    public Iterable<Hardware> listHardwareProfiles() {
-      Set<Hardware> hardware = Sets.newLinkedHashSet();
-      // todo they are only placeholders at the moment
-      hardware.add(new HardwareBuilder().ids("micro").hypervisor("lxc").name("micro").processor(new Processor(1, 1)).ram(512).build());
-      hardware.add(new HardwareBuilder().ids("small").hypervisor("lxc").name("small").processor(new Processor(1, 1)).ram(1024).build());
-      hardware.add(new HardwareBuilder().ids("medium").hypervisor("lxc").name("medium").processor(new Processor(2, 1)).ram(2048).build());
-      hardware.add(new HardwareBuilder().ids("large").hypervisor("lxc").name("large").processor(new Processor(4, 1)).ram(4096).build());
-      return hardware;
+      return hardwareProfileSupplier.get();
    }
 
    @Override

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/suppliers/VirtualHardwareConfigSupplier.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/suppliers/VirtualHardwareConfigSupplier.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.vcloud.director.v1_5.compute.suppliers;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.jclouds.compute.domain.Hardware;
+import org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants;
+import org.jclouds.vcloud.director.v1_5.compute.util.HardwareProfiles;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSet;
+
+public class VirtualHardwareConfigSupplier implements Supplier<Set<Hardware>> {
+
+   private final ImmutableSet<Hardware> hardwareConfigs;
+
+   @Inject
+   public VirtualHardwareConfigSupplier(@Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU) int maxCpuFromProperties,
+                                        @Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM) int minRamFromProperties,
+                                        @Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM) int maxRamFromProperties) {
+      // Synthetic profiles
+      ImmutableSet.Builder<Hardware> builder = ImmutableSet.builder();
+      for (int cpu = 1; cpu <= maxCpuFromProperties; cpu *= 2) {
+         for (int ram = minRamFromProperties; ram <= maxRamFromProperties; ram *= 2) {
+            builder.add(HardwareProfiles.createHardwareProfile(cpu, ram));
+         }
+      }
+
+      this.hardwareConfigs = builder.build();
+   }
+
+   @Override
+   public Set<Hardware> get() {
+      return hardwareConfigs;
+   }
+}

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/util/HardwareProfiles.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/util/HardwareProfiles.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.vcloud.director.v1_5.compute.util;
+
+import org.jclouds.compute.domain.Hardware;
+import org.jclouds.compute.domain.HardwareBuilder;
+import org.jclouds.compute.domain.Processor;
+
+public class HardwareProfiles {
+
+   public static Hardware createHardwareProfile(int numCpu, int ramAllocatedMB) {
+
+      String shortName;
+      if ((ramAllocatedMB & 0x3ff) == 0) {
+         // Exact multiple of 1024
+         int ramAllocatedGB = ramAllocatedMB >> 10;
+         shortName = String.format("%dCPU_%dGB_RAM", numCpu, ramAllocatedGB);
+      } else {
+         // Inexact multiple of 1024
+         double ramAllocatedGB = ((double) ramAllocatedMB) / 1024.0;
+         shortName = String.format("%dCPU_%sGB_RAM", numCpu, Double.toString(ramAllocatedGB));
+      }
+
+      return new HardwareBuilder().ids(shortName).hypervisor("esxi").name(shortName).processor(new Processor(numCpu, 1)).ram(ramAllocatedMB).build();
+   }
+}

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapterLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapterLiveTest.java
@@ -28,6 +28,7 @@ import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.sshj.config.SshjSshClientModule;
 import org.jclouds.vcloud.director.v1_5.VCloudDirectorApi;
+import org.jclouds.vcloud.director.v1_5.compute.options.VCloudDirectorTemplateOptions;
 import org.jclouds.vcloud.director.v1_5.domain.Vm;
 import org.jclouds.vcloud.director.v1_5.internal.BaseVCloudDirectorApiLiveTest;
 import org.testng.annotations.AfterGroups;
@@ -66,9 +67,11 @@ public class VCloudDirectorComputeServiceAdapterLiveTest extends BaseVCloudDirec
               .imageNameMatches("CentOS_66_x64_platform") // TAI2.0
               .build();
 
-      template.getOptions()
+      VCloudDirectorTemplateOptions options = template.getOptions().as(VCloudDirectorTemplateOptions.class);
+      options //.memory(1024)
               //.networks("Deployment_Network_01"); // TAI
               .networks("Operational_Network_01"); // TAI2.0
+
       /*
       template.getOptions().runScript("winrm quickconfig -q & " +
               "winrm set winrm/config/service/auth @{Basic=\"true\"} & " +

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceContextLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceContextLiveTest.java
@@ -24,7 +24,6 @@ import javax.inject.Named;
 import org.jclouds.ContextBuilder;
 import org.jclouds.compute.ComputeServiceContext;
 import org.jclouds.compute.RunNodesException;
-import org.jclouds.compute.domain.ExecResponse;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.domain.TemplateBuilder;
@@ -32,7 +31,6 @@ import org.jclouds.compute.internal.BaseComputeServiceContextLiveTest;
 import org.jclouds.compute.reference.ComputeServiceConstants;
 import org.jclouds.logging.Logger;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
-import org.jclouds.ssh.SshClient;
 import org.jclouds.sshj.config.SshjSshClientModule;
 import org.jclouds.vcloud.director.v1_5.compute.options.VCloudDirectorTemplateOptions;
 import org.testng.annotations.Test;
@@ -67,23 +65,26 @@ public class VCloudDirectorComputeServiceContextLiveTest extends BaseComputeServ
               .locationId("https://emea01.canopy-cloud.com/api/vdc/e931a09d-131f-4aaa-a667-efbe02eba428") // TAI2.0
               //.imageNameMatches("centos6.4x64") // TAI
               .imageNameMatches("CentOS_66_x64_platform") // TAI2.0
+              .minCores(4)
+              .minRam(2048)
               .build();
       // test passing custom options
       VCloudDirectorTemplateOptions options = template.getOptions().as(VCloudDirectorTemplateOptions.class);
 
-      options
+      options.memory(1024);
+      // .networks("Operational_Network_01"); // TAI2.0
       //.networks("Deployment_Network_01"); // TAI
-      //.networks("Operational_Network_01"); // TAI2.0
-              .networks("Operational_Network_01"); // TAI2.0
+
+      options.networks("Operational_Network_01"); // TAI2.0
       NodeMetadata node = null;
       try {
          Set<? extends NodeMetadata> nodes = context.getComputeService().createNodesInGroup(name, 1, template);
          node = Iterables.getOnlyElement(nodes);
-         logger.debug("Created Node: %s", node);
-         SshClient client = context.utils().sshForNode().apply(node);
-         client.connect();
-         ExecResponse hello = client.exec("mount");
-         logger.debug(hello.getOutput().trim());
+//         logger.debug("Created Node: %s", node);
+//         SshClient client = context.utils().sshForNode().apply(node);
+//         client.connect();
+//         ExecResponse hello = client.exec("mount");
+//         logger.debug(hello.getOutput().trim());
       } finally {
          if (node != null) {
             context.getComputeService().destroyNode(node.getId());


### PR DESCRIPTION
@aledsage This adds support for hardwareId, so by default jclouds will now use hardwareProfile defined as usual.
It also introduces `VCloudTemplateOptions.memory` and ``VCloudTemplateOptions.virtualCpus` custom template options. These are intended to give fine-grain control on the hardware spec.

If `hardwareId` and `VCloudTemplateOptions.memory` or `VCloudTemplateOptions.virtualCpus` are defined, `VCloudTemplateOptions` will override the values of the `hardwareId` 
Notice an `hardwareId` is always chosen by jclouds under the covers.
