### PR TITLE
Feature: more hardware profiles

### DIFF
--- a/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
@@ -24,6 +24,7 @@ import static org.jclouds.reflect.Reflection2.typeToken;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM;
+import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_PREDEFINED_HARDWARE_PROFILES;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_TIMEOUT_TASK_COMPLETED;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_VERSION_SCHEMA;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_XML_NAMESPACE;
@@ -75,7 +76,8 @@ public class VCloudDirectorApiMetadata extends BaseHttpApiMetadata<VCloudDirecto
 
       properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU, "" + 8);
       properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM, "" + 512);
-      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM, "" + 1024 * 8);
+      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM, "" + 1024 * 32);
+      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_PREDEFINED_HARDWARE_PROFILES, "");
 
       properties.setProperty(TIMEOUT_NODE_TERMINATED, "" + 5 * 60 * 1000);
       properties.setProperty(TIMEOUT_NODE_SUSPENDED, "" + 5 * 60 * 1000);

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorConstants.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorConstants.java
@@ -60,6 +60,11 @@ public final class VCloudDirectorConstants {
     */
    public static final String PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM = "jclouds.vcloud-director.hardware-profiles.max-ram";
 
+   /**
+    * For synthesizing hardware profiles, the maximum number of CPUs.
+    */
+   public static final String PROPERTY_VCLOUD_DIRECTOR_PREDEFINED_HARDWARE_PROFILES = "jclouds.vcloud-director.hardware-profiles.predefined";
+
    /** TODO javadoc */
    /*
    public static final TypeToken<RestContext<SessionApi, SessionAsyncApi>> SESSION_CONTEXT_TYPE =

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/suppliers/VirtualHardwareConfigSupplier.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/suppliers/VirtualHardwareConfigSupplier.java
@@ -25,6 +25,7 @@ import org.jclouds.compute.domain.Hardware;
 import org.jclouds.vcloud.director.v1_5.VCloudDirectorConstants;
 import org.jclouds.vcloud.director.v1_5.compute.util.HardwareProfiles;
 
+import com.google.common.base.Splitter;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
 
@@ -35,15 +36,21 @@ public class VirtualHardwareConfigSupplier implements Supplier<Set<Hardware>> {
    @Inject
    public VirtualHardwareConfigSupplier(@Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU) int maxCpuFromProperties,
                                         @Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM) int minRamFromProperties,
-                                        @Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM) int maxRamFromProperties) {
+                                        @Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_RAM) int maxRamFromProperties,
+                                        @Named(VCloudDirectorConstants.PROPERTY_VCLOUD_DIRECTOR_PREDEFINED_HARDWARE_PROFILES) String predefinedProfiles) {
       // Synthetic profiles
       ImmutableSet.Builder<Hardware> builder = ImmutableSet.builder();
-      for (int cpu = 1; cpu <= maxCpuFromProperties; cpu *= 2) {
+      for (int cpu = 1; cpu <= maxCpuFromProperties; cpu++) {
          for (int ram = minRamFromProperties; ram <= maxRamFromProperties; ram *= 2) {
             builder.add(HardwareProfiles.createHardwareProfile(cpu, ram));
          }
       }
-
+      // Predefined profiles, supplied explicitly by the user
+      if (predefinedProfiles != null) {
+         for (String profile : Splitter.on(",").trimResults().omitEmptyStrings().split(predefinedProfiles)) {
+            builder.add(HardwareProfiles.createHardwareProfile(profile));
+         }
+      }
       this.hardwareConfigs = builder.build();
    }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/util/HardwareProfiles.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/util/HardwareProfiles.java
@@ -16,11 +16,16 @@
  */
 package org.jclouds.vcloud.director.v1_5.compute.util;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.HardwareBuilder;
 import org.jclouds.compute.domain.Processor;
 
 public class HardwareProfiles {
+
+   public static final Pattern SHORT_NAME_PATTERN = Pattern.compile("([0-9]+)CPU_([0-9\\.]+)GB_RAM");
 
    public static Hardware createHardwareProfile(int numCpu, int ramAllocatedMB) {
 
@@ -36,5 +41,18 @@ public class HardwareProfiles {
       }
 
       return new HardwareBuilder().ids(shortName).hypervisor("esxi").name(shortName).processor(new Processor(numCpu, 1)).ram(ramAllocatedMB).build();
+   }
+   
+   public static Hardware createHardwareProfile(String shortName) {
+      Matcher matcher = SHORT_NAME_PATTERN.matcher(shortName);
+      if (!matcher.matches()) {
+          throw new IllegalArgumentException("Invalid hardware profile '" + shortName + "'");
+      }
+      String cpus = matcher.group(1);
+      String ram = matcher.group(2);
+      int numCpus = Integer.parseInt(cpus);
+      int ramAllocatedMB = (int) (Double.parseDouble(ram) * 1024);
+
+      return new HardwareBuilder().ids(shortName).hypervisor("esxi").name(shortName).processor(new Processor(numCpus, 1)).ram(ramAllocatedMB).build();
    }
 }

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/compute/util/HardwareProfilesTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/compute/util/HardwareProfilesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.vcloud.director.v1_5.compute.util;
+
+import static org.testng.Assert.assertEquals;
+
+import org.jclouds.compute.domain.Hardware;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
+
+public class HardwareProfilesTest {
+
+   @Test
+   public void testHardwareProfileFromName() throws Exception {
+      Hardware hardware = HardwareProfiles.createHardwareProfile("2CPU_4GB_RAM");
+      assertEquals(Iterables.getOnlyElement(hardware.getProcessors()).getCores(), 2.0D);
+      assertEquals(hardware.getRam(), 4 * 1024);
+      assertEquals(hardware.getHypervisor(), "esxi");
+      assertEquals(hardware.getName(), "2CPU_4GB_RAM");
+   }
+   
+   @Test
+   public void testHardwareProfileFromNameWithRamFraction() throws Exception {
+      Hardware hardware = HardwareProfiles.createHardwareProfile("2CPU_0.5GB_RAM");
+      assertEquals(Iterables.getOnlyElement(hardware.getProcessors()).getCores(), 2.0D);
+      assertEquals(hardware.getRam(), 1024 / 2);
+      assertEquals(hardware.getHypervisor(), "esxi");
+      assertEquals(hardware.getName(), "2CPU_0.5GB_RAM");
+   }
+   
+   @Test
+   public void testHardwareProfileFromParts() throws Exception {
+      Hardware hardware = HardwareProfiles.createHardwareProfile(2, 4 * 1024);
+      assertEquals(Iterables.getOnlyElement(hardware.getProcessors()).getCores(), 2.0D);
+      assertEquals(hardware.getRam(), 4 * 1024);
+      assertEquals(hardware.getHypervisor(), "esxi");
+      assertEquals(hardware.getName(), "2CPU_4GB_RAM");
+   }
+   
+   @Test
+   public void testHardwareProfileFromPartsWithRamFraction() throws Exception {
+      Hardware hardware = HardwareProfiles.createHardwareProfile(2, 1024 / 2);
+      assertEquals(Iterables.getOnlyElement(hardware.getProcessors()).getCores(), 2.0D);
+      assertEquals(hardware.getRam(), 1024 / 2);
+      assertEquals(hardware.getHypervisor(), "esxi");
+      assertEquals(hardware.getName(), "2CPU_0.5GB_RAM");
+   }
+}


### PR DESCRIPTION
- Change defaults to max 32GB RAM (from 8GB)
- CPU increments in steps of 1
- Adds jclouds.vcloud-director.hardware-profiles.predefined config,
  which gives a comma-separated list of additional hardware profiles.
