### PR TITLE
remove useless ACCEPT_ENCODING and CONTENT_ENCODING from BindUserOrgA…

### DIFF
--- a/src/main/java/org/jclouds/vcloud/director/v1_5/binders/BindUserOrgAndPasswordAsBasicAuthorizationHeader.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/binders/BindUserOrgAndPasswordAsBasicAuthorizationHeader.java
@@ -46,8 +46,6 @@ public class BindUserOrgAndPasswordAsBasicAuthorizationHeader implements MapBind
                         checkNotNull(postParams.get("org"), "org"),
                         checkNotNull(postParams.get("password"), "password")).getBytes(UTF_8));
       return (R) request.toBuilder()
-              .replaceHeader(HttpHeaders.ACCEPT_ENCODING, "gzip")
-              .replaceHeader(HttpHeaders.CONTENT_ENCODING, "gzip")
               .replaceHeader(HttpHeaders.ACCEPT, "application/*+xml;version=1.5")
               .replaceHeader(HttpHeaders.AUTHORIZATION, header).build();
    }


### PR DESCRIPTION
…ndPasswordAsBasicAuthorizationHeader

Commit was included in the branch `release/1.9.1-20151118.1705`, but was not in `1.9.x`.
