### PR TITLE
Fix/jclouds 2.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,8 +189,9 @@
       </plugin>
 
       <!-- 
-      Workaround to change to java17 compatibility, rather than java16.
-      Could upgrade from 1.11 to 1.15 as well.
+      Workaround to change to java17 compatibility, rather than java16
+      Also updates version from 1.11 to 1.15.
+      (i.e. overriding the jclouds 2.0.0 defaults, copy-pasting from jclouds project/pom.xml).
        -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -215,11 +216,16 @@
 
       <!-- 
       Workaround for https://github.com/google/error-prone/issues/493 with error-prone 2.0.5.
-      Update to 2.0.15, and disable a bunch of checkers that were not found.
+      Disables individual checkers - see comments below.
+      Updates plexus-compiler-javac-errorprone version from 2.6 to 2.8.1 (no specific reason!).
+      Updates maven-compiler-plugin version from 3.1 to 3.6.0 (no specific reason!).
+      (Don't upgrade error-prone beyone 2.0.5 until we are dropping support for Java 7 - see 
+      https://github.com/tbroyer/gradle-errorprone-plugin/issues/18).
+      (i.e. overriding the jclouds 2.0.0 defaults, copy-pasting from jclouds project/pom.xml).
        -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.6.0</version>
         <configuration>
           <compilerId>javac-with-errorprone</compilerId>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,8 @@
               <!-- on by default: warning -->
               <compilerArg>-Xep:CannotMockFinalClass:ERROR</compilerArg>
               <compilerArg>-Xep:ElementsCountedInLoop:ERROR</compilerArg>
-              <compilerArg>-Xep:EqualsHashCode:ERROR</compilerArg>
+              <!-- Disabled for error-prone 2.0.5 -->
+              <!--<compilerArg>-Xep:EqualsHashCode:ERROR</compilerArg>-->
               <compilerArg>-Xep:Finally:ERROR</compilerArg>
               <compilerArg>-Xep:IncompatibleModifiers:ERROR</compilerArg>
               <compilerArg>-Xep:JUnitAmbiguousTestClass:ERROR</compilerArg>
@@ -309,7 +310,8 @@
 
               <!-- experimental: warning -->
               <compilerArg>-Xep:AssertFalse:ERROR</compilerArg>
-              <compilerArg>-Xep:AssistedInjectAndInjectOnConstructors:ERROR</compilerArg>
+              <!-- Disabled for error-prone 2.0.5: NPE -->
+              <!--<compilerArg>-Xep:AssistedInjectAndInjectOnConstructors:ERROR</compilerArg>-->
               <compilerArg>-Xep:CollectionIncompatibleType:ERROR</compilerArg>
               <compilerArg>-Xep:GuiceInjectOnFinalField:OFF</compilerArg>  <!-- noisy -->
               <compilerArg>-Xep:MissingFail:ERROR</compilerArg>
@@ -370,7 +372,7 @@
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.0.15</version>
+            <version>2.0.5</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,196 @@
           <exclusionsFile>resources/modernizer_exclusions.txt</exclusionsFile>
         </configuration>
       </plugin>
+
+      <!-- 
+      Workaround to change to java17 compatibility, rather than java16.
+      Could upgrade from 1.11 to 1.15 as well.
+       -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.15</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java17</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+      </plugin>
+
+      <!-- 
+      Workaround for https://github.com/google/error-prone/issues/493 with error-prone 2.0.5.
+      Update to 2.0.15, and disable a bunch of checkers that were not found.
+       -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <compilerId>javac-with-errorprone</compilerId>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <source>${maven.compile.source}</source>
+          <target>${maven.compile.target}</target>
+            <showDeprecation>false</showDeprecation>
+            <showWarnings>true</showWarnings>
+            <compilerArgs>
+              <compilerArg>-Xlint</compilerArg>
+              <compilerArg>-Xlint:-deprecation</compilerArg>
+              <compilerArg>-Xlint:-rawtypes</compilerArg>
+              <compilerArg>-Xlint:-serial</compilerArg>
+              <compilerArg>-Xlint:-unchecked</compilerArg>
+
+              <!-- on by default: warning -->
+              <compilerArg>-Xep:CannotMockFinalClass:ERROR</compilerArg>
+              <compilerArg>-Xep:ElementsCountedInLoop:ERROR</compilerArg>
+              <compilerArg>-Xep:EqualsHashCode:ERROR</compilerArg>
+              <compilerArg>-Xep:Finally:ERROR</compilerArg>
+              <compilerArg>-Xep:IncompatibleModifiers:ERROR</compilerArg>
+              <compilerArg>-Xep:JUnitAmbiguousTestClass:ERROR</compilerArg>
+              <compilerArg>-Xep:NonAtomicVolatileUpdate:OFF</compilerArg>  <!-- noisy -->
+              <compilerArg>-Xep:NonCanonicalStaticMemberImport:ERROR</compilerArg>
+              <compilerArg>-Xep:NonOverridingEquals:ERROR</compilerArg>
+              <compilerArg>-Xep:PreconditionsInvalidPlaceholder:ERROR</compilerArg>
+              <compilerArg>-Xep:ProtoFieldPreconditionsCheckNotNull:ERROR</compilerArg>
+              <compilerArg>-Xep:RequiredModifiers:ERROR</compilerArg>
+              <compilerArg>-Xep:StaticAccessedFromInstance:ERROR</compilerArg>
+              <compilerArg>-Xep:StringEquality:ERROR</compilerArg>
+              <compilerArg>-Xep:SynchronizeOnNonFinalField:ERROR</compilerArg>
+              <compilerArg>-Xep:TypeParameterUnusedInFormals:OFF</compilerArg>  <!-- noisy -->
+              <compilerArg>-Xep:UnnecessaryStaticImport:ERROR</compilerArg>
+              <compilerArg>-Xep:WaitNotInLoop:ERROR</compilerArg>
+
+              <!-- on by default: error -->
+              <compilerArg>-Xep:ArrayEquals:ERROR</compilerArg>
+              <compilerArg>-Xep:ArrayHashCode:ERROR</compilerArg>
+              <compilerArg>-Xep:ArrayToString:ERROR</compilerArg>
+              
+              <!-- Disabled for error-prone 2.0.15: e.g. "ArrayToStringCompoundAssignment is not a valid checker name"
+              <compilerArg>-Xep:ArrayToStringCompoundAssignment:ERROR</compilerArg>
+              <compilerArg>-Xep:ArrayToStringConcatenation:ERROR</compilerArg>
+               -->
+              <compilerArg>-Xep:AsyncFunctionReturnsNull:ERROR</compilerArg>
+              <compilerArg>-Xep:BadShiftAmount:ERROR</compilerArg>
+              <compilerArg>-Xep:ChainingConstructorIgnoresParameter:ERROR</compilerArg>
+              <compilerArg>-Xep:CheckReturnValue:ERROR</compilerArg>
+              <compilerArg>-Xep:ClassName:ERROR</compilerArg>
+              <compilerArg>-Xep:ComparisonOutOfRange:ERROR</compilerArg>
+              <compilerArg>-Xep:CompileTimeConstant:ERROR</compilerArg>
+              <compilerArg>-Xep:DeadException:ERROR</compilerArg>
+              <compilerArg>-Xep:DepAnn:ERROR</compilerArg>
+              <compilerArg>-Xep:DoubleCheckedLocking:ERROR</compilerArg>
+              <compilerArg>-Xep:EqualsNaN:ERROR</compilerArg>
+              <compilerArg>-Xep:ForOverride:ERROR</compilerArg>
+              <compilerArg>-Xep:GetClassOnClass:ERROR</compilerArg>
+              <compilerArg>-Xep:GuardedByChecker:ERROR</compilerArg>
+              <compilerArg>-Xep:GuiceAssistedInjectScoping:ERROR</compilerArg>
+              <compilerArg>-Xep:HashtableContains:ERROR</compilerArg>
+              <compilerArg>-Xep:InvalidPatternSyntax:ERROR</compilerArg>
+              <compilerArg>-Xep:IsInstanceOfClass:ERROR</compilerArg>
+              <compilerArg>-Xep:JUnit3TestNotRun:ERROR</compilerArg>
+              <compilerArg>-Xep:JUnit4SetUpNotRun:ERROR</compilerArg>
+              <compilerArg>-Xep:JUnit4TearDownNotRun:ERROR</compilerArg>
+              <compilerArg>-Xep:JUnit4TestNotRun:ERROR</compilerArg>
+              <compilerArg>-Xep:LongLiteralLowerCaseSuffix:ERROR</compilerArg>
+              <compilerArg>-Xep:MisusedWeekYear:ERROR</compilerArg>
+              <compilerArg>-Xep:NarrowingCompoundAssignment:ERROR</compilerArg>
+              <compilerArg>-Xep:NonCanonicalStaticImport:ERROR</compilerArg>
+              <compilerArg>-Xep:NonFinalCompileTimeConstant:ERROR</compilerArg>
+              <compilerArg>-Xep:Overrides:ERROR</compilerArg>
+              <!-- Disabled because of internal error on Windows with 2.0.5, see https://github.com/google/error-prone/issues/432 -->
+              <!-- <compilerArg>-Xep:PackageLocation:WARNING</compilerArg> -->
+              <compilerArg>-Xep:PreconditionsCheckNotNull:ERROR</compilerArg>
+              <compilerArg>-Xep:PreconditionsCheckNotNullPrimitive:ERROR</compilerArg>
+              <compilerArg>-Xep:ProtoFieldNullComparison:ERROR</compilerArg>
+              <compilerArg>-Xep:ReturnValueIgnored:ERROR</compilerArg>
+              <compilerArg>-Xep:SelfAssignment:ERROR</compilerArg>
+              <compilerArg>-Xep:SelfEquals:ERROR</compilerArg>
+              <compilerArg>-Xep:SizeGreaterThanOrEqualsZero:ERROR</compilerArg>
+              <compilerArg>-Xep:StringBuilderInitWithChar:ERROR</compilerArg>
+              <compilerArg>-Xep:SuppressWarningsDeprecated:ERROR</compilerArg>
+              <compilerArg>-Xep:TryFailThrowable:ERROR</compilerArg>
+              <compilerArg>-Xep:UnnecessaryTypeArgument:ERROR</compilerArg>
+              <compilerArg>-Xep:UnusedAnonymousClass:ERROR</compilerArg>
+
+              <!-- experimental: warning -->
+              <compilerArg>-Xep:AssertFalse:ERROR</compilerArg>
+              <compilerArg>-Xep:AssistedInjectAndInjectOnConstructors:ERROR</compilerArg>
+              <compilerArg>-Xep:CollectionIncompatibleType:ERROR</compilerArg>
+              <compilerArg>-Xep:GuiceInjectOnFinalField:OFF</compilerArg>  <!-- noisy -->
+              <compilerArg>-Xep:MissingFail:ERROR</compilerArg>
+              <compilerArg>-Xep:NullablePrimitive:ERROR</compilerArg>
+              <compilerArg>-Xep:OverridesGuiceInjectableMethod:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
+              <!-- Disabled for error-prone 2.0.15: e.g. "PreconditionsErrorMessageEagerEvaluation is not a valid checker name -->
+              <!-- <compilerArg>-Xep:PreconditionsErrorMessageEagerEvaluation:OFF</compilerArg> --> <!-- internal error with 2.0.5 -->
+              
+              <compilerArg>-Xep:PrimitiveArrayPassedToVarargsMethod:ERROR</compilerArg>
+
+              <!-- experimental: not a problem -->
+              <!-- Disabled for error-prone 2.0.15: e.g. "FallthroughSuppression is not a valid checker name
+              <compilerArg>-Xep:FallthroughSuppression</compilerArg>
+              -->
+
+              <!-- experimental: error -->
+              <compilerArg>-Xep:ArraysAsListPrimitiveArray:ERROR</compilerArg>
+              <compilerArg>-Xep:AssistedInjectAndInjectOnSameConstructor:ERROR</compilerArg>
+              <compilerArg>-Xep:ClassCanBeStatic:ERROR</compilerArg>
+              <compilerArg>-Xep:DivZero:ERROR</compilerArg>
+              <compilerArg>-Xep:EmptyIf:ERROR</compilerArg>
+              <compilerArg>-Xep:GuardedByValidator:ERROR</compilerArg>
+              <compilerArg>-Xep:GuiceAssistedParameters:ERROR</compilerArg>
+              <compilerArg>-Xep:InjectInvalidTargetingOnScopingAnnotation:ERROR</compilerArg>
+              <compilerArg>-Xep:InjectMoreThanOneQualifier:OFF</compilerArg>  <!-- noisy -->
+              <compilerArg>-Xep:InjectMoreThanOneScopeAnnotationOnClass:ERROR</compilerArg>
+              <compilerArg>-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass:ERROR</compilerArg>
+              <compilerArg>-Xep:InjectScopeOrQualifierAnnotationRetention:ERROR</compilerArg>
+              <compilerArg>-Xep:InjectedConstructorAnnotations:ERROR</compilerArg>
+              <compilerArg>-Xep:JMockTestWithoutRunWithOrRuleAnnotation:ERROR</compilerArg>
+              <compilerArg>-Xep:JavaxInjectOnAbstractMethod:ERROR</compilerArg>
+              <compilerArg>-Xep:JavaxInjectOnFinalField:ERROR</compilerArg>
+              <compilerArg>-Xep:LockMethodChecker:ERROR</compilerArg>
+              <!-- Disabled for error-prone 2.0.15: e.g. "MalformedFormatString is not a valid checker name
+              <compilerArg>-Xep:MalformedFormatString:ERROR</compilerArg>
+              -->
+              <compilerArg>-Xep:MissingCasesInEnumSwitch:OFF</compilerArg>  <!-- noisy -->
+              <compilerArg>-Xep:ModifyingCollectionWithItself:ERROR</compilerArg>
+              <compilerArg>-Xep:MoreThanOneInjectableConstructor:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
+              <compilerArg>-Xep:NoAllocation:ERROR</compilerArg>
+              <compilerArg>-Xep:NonRuntimeAnnotation:ERROR</compilerArg>
+              <compilerArg>-Xep:NumericEquality:ERROR</compilerArg>
+              <compilerArg>-Xep:OverlappingQualifierAndScopeAnnotation:ERROR</compilerArg>
+              <compilerArg>-Xep:OverridesJavaxInjectableMethod:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
+              <compilerArg>-Xep:ParameterPackage:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
+              <compilerArg>-Xep:ProtoStringFieldReferenceEquality:ERROR</compilerArg>
+              <compilerArg>-Xep:SelfEquality:ERROR</compilerArg>
+              <compilerArg>-Xep:UnlockMethod:ERROR</compilerArg>
+              <compilerArg>-Xep:WildcardImport:ERROR</compilerArg>
+            </compilerArgs>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>2.8.1</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <version>2.0.15</version>
+            <scope>compile</scope>
+          </dependency>
+        </dependencies>
+      </plugin>
+ 
+ 
     </plugins>
   </build>
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApi.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApi.java
@@ -56,8 +56,6 @@ import org.jclouds.vcloud.director.v1_5.filters.AddVCloudAuthorizationAndCookieT
 import org.jclouds.vcloud.director.v1_5.functions.URNToHref;
 import org.jclouds.vcloud.director.v1_5.login.SessionApi;
 
-import com.google.inject.Provides;
-
 /**
  * Provides access to VCloudDirector via their REST API.
  */
@@ -81,7 +79,6 @@ public interface VCloudDirectorApi extends Closeable {
    /**
     * @return the current login session
     */
-   @Provides
    Session getCurrentSession();
 
    /**

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorApiMetadata.java
@@ -74,7 +74,7 @@ public class VCloudDirectorApiMetadata extends BaseHttpApiMetadata<VCloudDirecto
 
       // TODO integrate these with the {@link ComputeTimeouts} instead of having a single timeout for everything.
       properties.setProperty(PROPERTY_SESSION_INTERVAL, Integer.toString(300));
-      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_TIMEOUT_TASK_COMPLETED, Long.toString(1200l * 1000l));
+      properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_TIMEOUT_TASK_COMPLETED, Long.toString(1200L * 1000L));
 
       properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MAX_CPU, "" + 8);
       properties.setProperty(PROPERTY_VCLOUD_DIRECTOR_HARDWARE_MIN_RAM, "" + 512);

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorException.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/VCloudDirectorException.java
@@ -27,6 +27,8 @@ import com.google.common.collect.Iterables;
 
 public class VCloudDirectorException extends RuntimeException {
 
+   private static final long serialVersionUID = 390956992843720220L;
+
    private static final String MSG_FMT = "%s (%d) %s: %s";   
 
    private final Error error;

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/builders/TemplateBuilderImpl.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/builders/TemplateBuilderImpl.java
@@ -16,50 +16,6 @@
  */
 package org.jclouds.vcloud.director.v1_5.builders;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Predicates.and;
-import static com.google.common.collect.Iterables.filter;
-import static com.google.common.collect.Iterables.find;
-import static com.google.common.collect.Iterables.size;
-import static com.google.common.collect.Iterables.transform;
-import static com.google.common.collect.Iterables.tryFind;
-import static com.google.common.collect.Lists.newArrayList;
-import static java.lang.String.format;
-import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
-import static org.jclouds.compute.util.ComputeServiceUtils.getCoresAndSpeed;
-import static org.jclouds.compute.util.ComputeServiceUtils.getSpace;
-
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.regex.Pattern;
-
-import javax.annotation.Resource;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Provider;
-
-import org.jclouds.collect.Memoized;
-import org.jclouds.compute.domain.ComputeMetadata;
-import org.jclouds.compute.domain.Hardware;
-import org.jclouds.compute.domain.Image;
-import org.jclouds.compute.domain.OperatingSystem;
-import org.jclouds.compute.domain.OsFamily;
-import org.jclouds.compute.domain.Template;
-import org.jclouds.compute.domain.TemplateBuilder;
-import org.jclouds.compute.domain.TemplateBuilderSpec;
-import org.jclouds.compute.domain.internal.NullEqualToIsParentOrIsGrandparentOfCurrentLocation;
-import org.jclouds.compute.domain.internal.TemplateImpl;
-import org.jclouds.compute.options.TemplateOptions;
-import org.jclouds.compute.reference.ComputeServiceConstants;
-import org.jclouds.compute.strategy.GetImageStrategy;
-import org.jclouds.compute.suppliers.ImageCacheSupplier;
-import org.jclouds.domain.Location;
-import org.jclouds.logging.Logger;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
@@ -74,446 +30,484 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.Doubles;
+import org.jclouds.collect.Memoized;
+import org.jclouds.compute.domain.ComputeMetadata;
+import org.jclouds.compute.domain.Hardware;
+import org.jclouds.compute.domain.Image;
+import org.jclouds.compute.domain.OperatingSystem;
+import org.jclouds.compute.domain.OsFamily;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.domain.TemplateBuilder;
+import org.jclouds.compute.domain.TemplateBuilderSpec;
+import org.jclouds.compute.domain.internal.NullEqualToIsParentOrIsGrandparentOfCurrentLocation;
+import org.jclouds.compute.domain.internal.TemplateImpl;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.compute.predicates.ImagePredicates;
+import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.compute.suppliers.ImageCacheSupplier;
+import org.jclouds.domain.Location;
+import org.jclouds.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.find;
+import static com.google.common.collect.Iterables.size;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Iterables.tryFind;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.String.format;
+import static org.jclouds.compute.util.ComputeServiceUtils.getCores;
+import static org.jclouds.compute.util.ComputeServiceUtils.getCoresAndSpeed;
+import static org.jclouds.compute.util.ComputeServiceUtils.getSpace;
 
 /**
- * This class is a copy of {@link TemplateBuilderImpl} implemented in jclouds 1.9.2.<br>
- * The reason for creating a copy is to allow the private method buildImagePredicate() to be overriden in child classes.<br>
- * <br>
- * What have been changed are the following fileds:<br><br>
- * {@code private idPredicate} changed to {@code protected idPredicate}<br>
- * {@code private osFamilyPredicate} changed to {@code protected osFamilyPredicate}<br>
- * {@code private osNamePredicate} changed to {@code protected osNamePredicate}<br>
- * {@code private osDescriptionPredicate} changed to {@code protected osDescriptionPredicate}<br>
- * {@code private osVersionPredicate} changed to {@code protected osVersionPredicate}<br>
- * {@code private os64BitPredicate} changed to {@code protected os64BitPredicate}<br>
- * {@code private osArchPredicate} changed to {@code protected osArchPredicate}<br>
- * {@code private imageVersionPredicate} changed to {@code protected imageVersionPredicate}<br>
- * {@code private imageNamePredicate} changed to {@code protected imageNamePredicate}<br>
- * {@code private imageDescriptionPredicate} changed to {@code protected imageDescriptionPredicate}<br>
- * <br>
- * and the method
- * <br> <br>
- * {@code private buildImagePredicate} changed to {@code protected buildImagePredicate()}
- *
+ * This class is a copy of {@link TemplateBuilderImpl} implemented in jclouds 2.0.0.
+ * <p>
+ * The reason for creating a copy is to allow the private method buildImagePredicate() to be 
+ * overridden in child classes.<br>
+ * <p>
+ * What have been changed are the following fields:
+ * <ul>
+ *   <li>{@code private osFamilyPredicate} changed to {@code protected}<br>
+ *   <li>{@code private osNamePredicate} changed to {@code protected}<br>
+ *   <li>{@code private osDescriptionPredicate} changed to {@code protected}<br>
+ *   <li>{@code private osVersionPredicate} changed to {@code protected}<br>
+ *   <li>{@code private os64BitPredicate} changed to {@code protected}<br>
+ *   <li>{@code private osArchPredicate} changed to {@code protected}<br>
+ *   <li>{@code private imageVersionPredicate} changed to {@code protected}<br>
+ *   <li>{@code private imageNamePredicate} changed to {@code protected}<br>
+ *   <li>{@code private imageDescriptionPredicate} changed to {@code protected}<br>
+ *   <li>{@code private hardwareIdPredicate} changed to {@code protected}<br>
+ *   <li>{@code private hardwareIdPredicate} changed to {@code protected}<br>
+ *   <li>{@code private hypervisorPredicate} changed to {@code protected}<br>
+ *   <li>{@code private hardwareCoresPredicate} changed to {@code protected}<br>
+ *   <li>{@code private hardwareDiskPredicate} changed to {@code protected}<br>
+ *   <li>{@code private hardwareRamPredicate} changed to {@code protected}<br>
+ * </ul>
+ * 
+ * The methods:
+ * <ul>
+ *   <li>{@code private buildImagePredicate()} changed to {@code protected}
+ *   <li>{@code private buildHardwarePredicate()} changed to {@code protected}<br>
+ * </ul>
+ * The imports added:
+ * <ul>
+ *   <li>{@code NullEqualToIsParentOrIsGrandparentOfCurrentLocation}
+ *   <li>{@code TemplateImpl}
+ * </ul>
  */
 public class TemplateBuilderImpl implements TemplateBuilder {
-    @Resource
-    @Named(ComputeServiceConstants.COMPUTE_LOGGER)
-    protected Logger logger = Logger.NULL;
+   @Resource
+   @Named(ComputeServiceConstants.COMPUTE_LOGGER)
+   protected Logger logger = Logger.NULL;
 
-    protected final ImageCacheSupplier images;
-    protected final Supplier<Set<? extends Hardware>> hardwares;
-    protected final Supplier<Set<? extends Location>> locations;
-    protected final Supplier<Location> defaultLocation;
-    protected final Provider<TemplateOptions> optionsProvider;
-    protected final Provider<TemplateBuilder> defaultTemplateProvider;
-    protected final GetImageStrategy getImageStrategy;
+   protected final ImageCacheSupplier images;
+   protected final Supplier<Set<? extends Hardware>> hardwares;
+   protected final Supplier<Set<? extends Location>> locations;
+   protected final Supplier<Location> defaultLocation;
+   protected final Provider<TemplateOptions> optionsProvider;
+   protected final Provider<TemplateBuilder> defaultTemplateProvider;
 
-    @VisibleForTesting
-    protected Location location;
-    @VisibleForTesting
-    protected String imageId;
-    @VisibleForTesting
-    protected String hardwareId;
-    @VisibleForTesting
-    protected String hypervisor;
-    @VisibleForTesting
-    protected String imageVersion;
-    @VisibleForTesting
-    protected OsFamily osFamily;
-    @VisibleForTesting
-    protected String osVersion;
-    @VisibleForTesting
-    protected Boolean os64Bit;
-    @VisibleForTesting
-    protected String osName;
-    @VisibleForTesting
-    protected String osDescription;
-    @VisibleForTesting
-    protected String osArch;
-    @VisibleForTesting
-    protected String imageName;
-    @VisibleForTesting
-    protected String imageDescription;
-    @VisibleForTesting
-    protected Predicate<Image> imagePredicate;
-    @VisibleForTesting
-    protected Function<Iterable<? extends Image>, Image> imageChooser;
-    @VisibleForTesting
-    protected double minCores;
-    @VisibleForTesting
-    protected int minRam;
-    @VisibleForTesting
-    protected double minDisk;
-    @VisibleForTesting
-    protected boolean biggest;
-    @VisibleForTesting
-    protected boolean fastest;
-    @VisibleForTesting
-    protected TemplateOptions options;
+   @VisibleForTesting
+   protected Location location;
+   @VisibleForTesting
+   protected String imageId;
+   @VisibleForTesting
+   protected String hardwareId;
+   @VisibleForTesting
+   protected String hypervisor;
+   @VisibleForTesting
+   protected String imageVersion;
+   @VisibleForTesting
+   protected OsFamily osFamily;
+   @VisibleForTesting
+   protected String osVersion;
+   @VisibleForTesting
+   protected Boolean os64Bit;
+   @VisibleForTesting
+   protected String osName;
+   @VisibleForTesting
+   protected String osDescription;
+   @VisibleForTesting
+   protected String osArch;
+   @VisibleForTesting
+   protected String imageName;
+   @VisibleForTesting
+   protected String imageDescription;
+   @VisibleForTesting
+   protected Predicate<Image> imagePredicate;
+   @VisibleForTesting
+   protected Function<Iterable<? extends Image>, Image> imageChooser;
+   @VisibleForTesting
+   protected double minCores;
+   @VisibleForTesting
+   protected int minRam;
+   @VisibleForTesting
+   protected double minDisk;
+   @VisibleForTesting
+   protected boolean biggest;
+   @VisibleForTesting
+   protected boolean fastest;
+   @VisibleForTesting
+   protected TemplateOptions options;
+   @VisibleForTesting
+   protected Boolean forceCacheReload;
 
-    @Inject
-    protected TemplateBuilderImpl(@Memoized Supplier<Set<? extends Location>> locations,
-                                  ImageCacheSupplier images, @Memoized Supplier<Set<? extends Hardware>> hardwares,
-                                  Supplier<Location> defaultLocation, @Named("DEFAULT") Provider<TemplateOptions> optionsProvider,
-                                  @Named("DEFAULT") Provider<TemplateBuilder> defaultTemplateProvider, GetImageStrategy getImageStrategy) {
-        this.locations = checkNotNull(locations, "locations");
-        this.images = checkNotNull(images, "images");
-        this.hardwares = checkNotNull(hardwares, "hardwares");
-        this.defaultLocation = checkNotNull(defaultLocation, "defaultLocation");
-        this.optionsProvider = checkNotNull(optionsProvider, "optionsProvider");
-        this.defaultTemplateProvider = checkNotNull(defaultTemplateProvider, "defaultTemplateProvider");
-        this.getImageStrategy = checkNotNull(getImageStrategy, "getImageStrategy");
-    }
+   @Inject
+   protected TemplateBuilderImpl(@Memoized Supplier<Set<? extends Location>> locations,
+         @Memoized Supplier<Set<? extends Image>> images, @Memoized Supplier<Set<? extends Hardware>> hardwares,
+         Supplier<Location> defaultLocation, @Named("DEFAULT") Provider<TemplateOptions> optionsProvider,
+         @Named("DEFAULT") Provider<TemplateBuilder> defaultTemplateProvider) {
+      this.locations = checkNotNull(locations, "locations");
+      checkArgument(images instanceof ImageCacheSupplier, "an instance of the ImageCacheSupplier is needed");
+      this.images = ImageCacheSupplier.class.cast(images);
+      this.hardwares = checkNotNull(hardwares, "hardwares");
+      this.defaultLocation = checkNotNull(defaultLocation, "defaultLocation");
+      this.optionsProvider = checkNotNull(optionsProvider, "optionsProvider");
+      this.defaultTemplateProvider = checkNotNull(defaultTemplateProvider, "defaultTemplateProvider");
+   }
 
-    static Predicate<Hardware> supportsImagesPredicate(final Iterable<? extends Image> images) {
-        return new Predicate<Hardware>() {
-            @Override
-            public boolean apply(final Hardware hardware) {
-                return Iterables.any(images, new Predicate<Image>() {
+   static Predicate<Hardware> supportsImagesPredicate(final Iterable<? extends Image> images) {
+      return new Predicate<Hardware>() {
+         @Override
+         public boolean apply(final Hardware hardware) {
+            return Iterables.any(images, new Predicate<Image>() {
 
-                    @Override
-                    public boolean apply(Image input) {
-                        return hardware.supportsImage().apply(input);
-                    }
+               @Override
+               public boolean apply(Image input) {
+                  return hardware.supportsImage().apply(input);
+               }
 
-                    @Override
-                    public String toString() {
-                        return "hardware(" + hardware + ").supportsImage()";
-                    }
+               @Override
+               public String toString() {
+                  return "hardware(" + hardware + ").supportsImage()";
+               }
 
-                });
-
-            }
-
-        };
-    }
-
-    final Predicate<ComputeMetadata> locationPredicate = new NullEqualToIsParentOrIsGrandparentOfCurrentLocation(new Supplier<Location>() {
-
-        @Override
-        public Location get() {
-            return location;
-        }
-
-    });
-
-    protected final Predicate<Image> idPredicate = new Predicate<Image>() {
-        @Override
-        public boolean apply(Image input) {
-            boolean returnVal = true;
-            if (imageId != null) {
-                returnVal = imageId.equals(input.getId());
-                // match our input params so that the later predicates pass.
-                if (returnVal) {
-                    fromImage(input);
-                }
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "imageId(" + imageId + ")";
-        }
-    };
-
-    protected final Predicate<OperatingSystem> osFamilyPredicate = new Predicate<OperatingSystem>() {
-
-        @Override
-        public boolean apply(OperatingSystem input) {
-            boolean returnVal = true;
-            if (osFamily != null)
-                returnVal = osFamily.equals(input.getFamily());
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "osFamily(" + osFamily + ")";
-        }
-    };
-
-    protected final Predicate<OperatingSystem> osNamePredicate = new Predicate<OperatingSystem>() {
-        @Override
-        public boolean apply(OperatingSystem input) {
-            boolean returnVal = true;
-            if (osName != null) {
-                if (input.getName() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getName().contains(osName) || input.getName().matches(osName);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "osName(" + osName + ")";
-        }
-    };
-
-    protected final Predicate<OperatingSystem> osDescriptionPredicate = new Predicate<OperatingSystem>() {
-        @Override
-        public boolean apply(OperatingSystem input) {
-            boolean returnVal = true;
-            if (osDescription != null) {
-                if (input.getDescription() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getDescription().contains(osDescription)
-                            || input.getDescription().matches(osDescription);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "osDescription(" + osDescription + ")";
-        }
-    };
-
-    protected final Predicate<OperatingSystem> osVersionPredicate = new Predicate<OperatingSystem>() {
-        @Override
-        public boolean apply(OperatingSystem input) {
-            boolean returnVal = true;
-            if (osVersion != null) {
-                if (input.getVersion() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getVersion().contains(osVersion) || input.getVersion().matches(osVersion);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "osVersion(" + osVersion + ")";
-        }
-    };
-
-    protected final Predicate<OperatingSystem> os64BitPredicate = new Predicate<OperatingSystem>() {
-        @Override
-        public boolean apply(OperatingSystem input) {
-            boolean returnVal = true;
-            if (os64Bit != null) {
-                if (os64Bit)
-                    return input.is64Bit();
-                else
-                    return !input.is64Bit();
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "os64Bit(" + os64Bit + ")";
-        }
-    };
-
-    protected final Predicate<OperatingSystem> osArchPredicate = new Predicate<OperatingSystem>() {
-        @Override
-        public boolean apply(OperatingSystem input) {
-            boolean returnVal = true;
-            if (osArch != null) {
-                if (input.getArch() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getArch().contains(osArch) || input.getArch().matches(osArch);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "osArch(" + osArch + ")";
-        }
-    };
-
-    protected final Predicate<Image> imageVersionPredicate = new Predicate<Image>() {
-        @Override
-        public boolean apply(Image input) {
-            boolean returnVal = true;
-            if (imageVersion != null) {
-                if (input.getVersion() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getVersion().contains(imageVersion) || input.getVersion().matches(imageVersion);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "imageVersion(" + imageVersion + ")";
-        }
-    };
-
-    protected final Predicate<Image> imageNamePredicate = new Predicate<Image>() {
-        @Override
-        public boolean apply(Image input) {
-            boolean returnVal = true;
-            if (imageName != null) {
-                if (input.getName() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getName().equals(imageName) || input.getName().contains(imageName)
-                            || input.getName().matches(imageName);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "imageName(" + imageName + ")";
-        }
-    };
-
-    protected final Predicate<Image> imageDescriptionPredicate = new Predicate<Image>() {
-        @Override
-        public boolean apply(Image input) {
-            boolean returnVal = true;
-            if (imageDescription != null) {
-                if (input.getDescription() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getDescription().equals(imageDescription)
-                            || input.getDescription().contains(imageDescription)
-                            || input.getDescription().matches(imageDescription);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "imageDescription(" + imageDescription + ")";
-        }
-    };
-
-    private final Predicate<Hardware> hardwareIdPredicate = new Predicate<Hardware>() {
-        @Override
-        public boolean apply(Hardware input) {
-            boolean returnVal = true;
-            if (hardwareId != null) {
-                returnVal = hardwareId.equals(input.getId());
-                // match our input params so that the later predicates pass.
-                if (returnVal) {
-                    fromHardware(input);
-                }
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "hardwareId(" + hardwareId + ")";
-        }
-    };
-
-    private final Predicate<Hardware> hypervisorPredicate = new Predicate<Hardware>() {
-        @Override
-        public boolean apply(Hardware input) {
-            boolean returnVal = true;
-            if (hypervisor != null) {
-                if (input.getHypervisor() == null)
-                    returnVal = false;
-                else
-                    returnVal = input.getHypervisor().contains(hypervisor)
-                            || input.getHypervisor().matches(hypervisor);
-            }
-            return returnVal;
-        }
-
-        @Override
-        public String toString() {
-            return "hypervisorMatches(" + hypervisor + ")";
-        }
-    };
-
-    private final Predicate<Hardware> hardwareCoresPredicate = new Predicate<Hardware>() {
-        @Override
-        public boolean apply(Hardware input) {
-            double cores = getCores(input);
-            return cores >= TemplateBuilderImpl.this.minCores;
-        }
-
-        @Override
-        public String toString() {
-            return "minCores(" + minCores + ")";
-        }
-    };
-
-    private final Predicate<Hardware> hardwareDiskPredicate = new Predicate<Hardware>() {
-        @Override
-        public boolean apply(Hardware input) {
-            return getSpace(input) >= TemplateBuilderImpl.this.minDisk;
-        }
-
-        @Override
-        public String toString() {
-            return "minDisk(" + minDisk + ")";
-        }
-    };
-
-    private final Predicate<Hardware> hardwareRamPredicate = new Predicate<Hardware>() {
-        @Override
-        public boolean apply(Hardware input) {
-            return input.getRam() >= TemplateBuilderImpl.this.minRam;
-        }
-
-        @Override
-        public String toString() {
-            return "minRam(" + minRam + ")";
-        }
-    };
-
-    private Predicate<Hardware> buildHardwarePredicate() {
-        List<Predicate<Hardware>> predicates = newArrayList();
-        if (location != null)
-            predicates.add(new Predicate<Hardware>() {
-
-                @Override
-                public boolean apply(Hardware input) {
-                    return locationPredicate.apply(input);
-                }
-
-                @Override
-                public String toString() {
-                    return locationPredicate.toString();
-                }
             });
-        if (hypervisor != null)
-            predicates.add(hypervisorPredicate);
-        predicates.add(hardwareCoresPredicate);
-        predicates.add(hardwareRamPredicate);
-        predicates.add(hardwareDiskPredicate);
 
-        // looks verbose, but explicit <Hardware> type needed for this to compile
-        // properly
-        Predicate<Hardware> hardwarePredicate = predicates.size() == 1 ? Iterables.<Predicate<Hardware>> get(predicates, 0)
-                : Predicates.<Hardware> and(predicates);
-        return hardwarePredicate;
-    }
+         }
 
-    static final Ordering<Hardware> DEFAULT_SIZE_ORDERING = new Ordering<Hardware>() {
-        public int compare(Hardware left, Hardware right) {
-            return ComparisonChain.start().compare(getCores(left), getCores(right)).compare(left.getRam(), right.getRam())
-                    .compare(getSpace(left), getSpace(right)).result();
-        }
-    };
-    static final Ordering<Hardware> BY_CORES_ORDERING = new Ordering<Hardware>() {
-        public int compare(Hardware left, Hardware right) {
-            return Doubles.compare(getCoresAndSpeed(left), getCoresAndSpeed(right));
-        }
-    };
-    static final Ordering<Hardware> NOT_DEPRECATED_ORDERING = new Ordering<Hardware>() {
-        public int compare(Hardware left, Hardware right) {
-            // we take max so deprecated items come first
-            return ComparisonChain.start().compareTrueFirst(left.isDeprecated(), right.isDeprecated()).result();
-        }
-    };
-    static final Ordering<Image> DEFAULT_IMAGE_ORDERING = new Ordering<Image>() {
-        public int compare(Image left, Image right) {
+      };
+   }
+
+   final Predicate<ComputeMetadata> locationPredicate = new NullEqualToIsParentOrIsGrandparentOfCurrentLocation(new Supplier<Location>() {
+
+      @Override
+      public Location get() {
+         return location;
+      }
+
+   });
+
+   protected final Predicate<OperatingSystem> osFamilyPredicate = new Predicate<OperatingSystem>() {
+
+      @Override
+      public boolean apply(OperatingSystem input) {
+         boolean returnVal = true;
+         if (osFamily != null)
+            returnVal = osFamily.equals(input.getFamily());
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "osFamily(" + osFamily + ")";
+      }
+   };
+
+   protected final Predicate<OperatingSystem> osNamePredicate = new Predicate<OperatingSystem>() {
+      @Override
+      public boolean apply(OperatingSystem input) {
+         boolean returnVal = true;
+         if (osName != null) {
+            if (input.getName() == null)
+               returnVal = false;
+            else
+               returnVal = input.getName().contains(osName) || input.getName().matches(osName);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "osName(" + osName + ")";
+      }
+   };
+
+   protected final Predicate<OperatingSystem> osDescriptionPredicate = new Predicate<OperatingSystem>() {
+      @Override
+      public boolean apply(OperatingSystem input) {
+         boolean returnVal = true;
+         if (osDescription != null) {
+            if (input.getDescription() == null)
+               returnVal = false;
+            else
+               returnVal = input.getDescription().contains(osDescription)
+                     || input.getDescription().matches(osDescription);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "osDescription(" + osDescription + ")";
+      }
+   };
+
+   protected final Predicate<OperatingSystem> osVersionPredicate = new Predicate<OperatingSystem>() {
+      @Override
+      public boolean apply(OperatingSystem input) {
+         boolean returnVal = true;
+         if (osVersion != null) {
+            if (input.getVersion() == null)
+               returnVal = false;
+            else
+               returnVal = input.getVersion().contains(osVersion) || input.getVersion().matches(osVersion);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "osVersion(" + osVersion + ")";
+      }
+   };
+
+   protected final Predicate<OperatingSystem> os64BitPredicate = new Predicate<OperatingSystem>() {
+      @Override
+      public boolean apply(OperatingSystem input) {
+         boolean returnVal = true;
+         if (os64Bit != null) {
+            if (os64Bit)
+               return input.is64Bit();
+            else
+               return !input.is64Bit();
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "os64Bit(" + os64Bit + ")";
+      }
+   };
+
+   protected final Predicate<OperatingSystem> osArchPredicate = new Predicate<OperatingSystem>() {
+      @Override
+      public boolean apply(OperatingSystem input) {
+         boolean returnVal = true;
+         if (osArch != null) {
+            if (input.getArch() == null)
+               returnVal = false;
+            else
+               returnVal = input.getArch().contains(osArch) || input.getArch().matches(osArch);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "osArch(" + osArch + ")";
+      }
+   };
+
+   protected final Predicate<Image> imageVersionPredicate = new Predicate<Image>() {
+      @Override
+      public boolean apply(Image input) {
+         boolean returnVal = true;
+         if (imageVersion != null) {
+            if (input.getVersion() == null)
+               returnVal = false;
+            else
+               returnVal = input.getVersion().contains(imageVersion) || input.getVersion().matches(imageVersion);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "imageVersion(" + imageVersion + ")";
+      }
+   };
+
+   protected final Predicate<Image> imageNamePredicate = new Predicate<Image>() {
+      @Override
+      public boolean apply(Image input) {
+         boolean returnVal = true;
+         if (imageName != null) {
+            if (input.getName() == null)
+               returnVal = false;
+            else
+               returnVal = input.getName().equals(imageName) || input.getName().contains(imageName)
+                        || input.getName().matches(imageName);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "imageName(" + imageName + ")";
+      }
+   };
+
+   protected final Predicate<Image> imageDescriptionPredicate = new Predicate<Image>() {
+      @Override
+      public boolean apply(Image input) {
+         boolean returnVal = true;
+         if (imageDescription != null) {
+            if (input.getDescription() == null)
+               returnVal = false;
+            else
+               returnVal = input.getDescription().equals(imageDescription)
+                     || input.getDescription().contains(imageDescription)
+                     || input.getDescription().matches(imageDescription);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "imageDescription(" + imageDescription + ")";
+      }
+   };
+   protected final Predicate<Hardware> hardwareIdPredicate = new Predicate<Hardware>() {
+      @Override
+      public boolean apply(Hardware input) {
+         boolean returnVal = true;
+         if (hardwareId != null) {
+            returnVal = hardwareId.equals(input.getId());
+            // match our input params so that the later predicates pass.
+            if (returnVal) {
+               fromHardware(input);
+            }
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "hardwareId(" + hardwareId + ")";
+      }
+   };
+
+   protected final Predicate<Hardware> hypervisorPredicate = new Predicate<Hardware>() {
+      @Override
+      public boolean apply(Hardware input) {
+         boolean returnVal = true;
+         if (hypervisor != null) {
+            if (input.getHypervisor() == null)
+               returnVal = false;
+            else
+               returnVal = input.getHypervisor().contains(hypervisor)
+                     || input.getHypervisor().matches(hypervisor);
+         }
+         return returnVal;
+      }
+
+      @Override
+      public String toString() {
+         return "hypervisorMatches(" + hypervisor + ")";
+      }
+   };
+
+   protected final Predicate<Hardware> hardwareCoresPredicate = new Predicate<Hardware>() {
+      @Override
+      public boolean apply(Hardware input) {
+         double cores = getCores(input);
+         return cores >= TemplateBuilderImpl.this.minCores;
+      }
+
+      @Override
+      public String toString() {
+         return "minCores(" + minCores + ")";
+      }
+   };
+
+   protected final Predicate<Hardware> hardwareDiskPredicate = new Predicate<Hardware>() {
+      @Override
+      public boolean apply(Hardware input) {
+         return getSpace(input) >= TemplateBuilderImpl.this.minDisk;
+      }
+
+      @Override
+      public String toString() {
+         return "minDisk(" + minDisk + ")";
+      }
+   };
+
+   protected final Predicate<Hardware> hardwareRamPredicate = new Predicate<Hardware>() {
+      @Override
+      public boolean apply(Hardware input) {
+         return input.getRam() >= TemplateBuilderImpl.this.minRam;
+      }
+
+      @Override
+      public String toString() {
+         return "minRam(" + minRam + ")";
+      }
+   };
+
+   protected Predicate<Hardware> buildHardwarePredicate() {
+      List<Predicate<Hardware>> predicates = newArrayList();
+      if (location != null)
+         predicates.add(new Predicate<Hardware>() {
+
+            @Override
+            public boolean apply(Hardware input) {
+               return locationPredicate.apply(input);
+            }
+
+            @Override
+            public String toString() {
+               return locationPredicate.toString();
+            }
+         });
+      if (hypervisor != null)
+         predicates.add(hypervisorPredicate);
+      predicates.add(hardwareCoresPredicate);
+      predicates.add(hardwareRamPredicate);
+      predicates.add(hardwareDiskPredicate);
+
+      // looks verbose, but explicit <Hardware> type needed for this to compile
+      // properly
+      Predicate<Hardware> hardwarePredicate = predicates.size() == 1 ? Iterables.<Predicate<Hardware>> get(predicates, 0)
+            : Predicates.<Hardware> and(predicates);
+      return hardwarePredicate;
+   }
+
+   static final Ordering<Hardware> DEFAULT_SIZE_ORDERING = new Ordering<Hardware>() {
+      public int compare(Hardware left, Hardware right) {
+         return ComparisonChain.start().compare(getCores(left), getCores(right)).compare(left.getRam(), right.getRam())
+               .compare(getSpace(left), getSpace(right)).result();
+      }
+   };
+   static final Ordering<Hardware> BY_CORES_ORDERING = new Ordering<Hardware>() {
+      public int compare(Hardware left, Hardware right) {
+         return Doubles.compare(getCoresAndSpeed(left), getCoresAndSpeed(right));
+      }
+   };
+   static final Ordering<Hardware> NOT_DEPRECATED_ORDERING = new Ordering<Hardware>() {
+      public int compare(Hardware left, Hardware right) {
+         // we take max so deprecated items come first
+         return ComparisonChain.start().compareTrueFirst(left.isDeprecated(), right.isDeprecated()).result();
+      }
+   };
+   static final Ordering<Image> DEFAULT_IMAGE_ORDERING = new Ordering<Image>() {
+      public int compare(Image left, Image right) {
          /* This currently, and for some time, has *preferred* images whose fields are null,
           * and prefers those which come last alphabetically.
           * It seems preferable to take images whose fields are *not* null, ie nullsFirst;
@@ -521,682 +515,677 @@ public class TemplateBuilderImpl implements TemplateBuilder {
           * (so "Ubuntu 13.04" would be preferred over "Ubuntu 9.10").
           * However not changing it now as people may be surprised if the images they get back start changing.
           */
-            return ComparisonChain.start()
-                    .compare(left.getName(), right.getName(), Ordering.<String> natural().nullsLast())
-                    .compare(left.getVersion(), right.getVersion(), Ordering.<String> natural().nullsLast())
-                    .compare(left.getDescription(), right.getDescription(), Ordering.<String> natural().nullsLast())
-                    .compare(left.getOperatingSystem().getName(), right.getOperatingSystem().getName(),
-                            Ordering.<String> natural().nullsLast())
-                    .compare(left.getOperatingSystem().getVersion(), right.getOperatingSystem().getVersion(),
-                            Ordering.<String> natural().nullsLast())
-                    .compare(left.getOperatingSystem().getDescription(), right.getOperatingSystem().getDescription(),
-                            Ordering.<String> natural().nullsLast())
-                    .compare(left.getOperatingSystem().getArch(), right.getOperatingSystem().getArch(),
-                            Ordering.<String> natural().nullsLast()).result();
-        }
-    };
+         return ComparisonChain.start()
+               .compare(left.getName(), right.getName(), Ordering.<String> natural().nullsLast())
+               .compare(left.getVersion(), right.getVersion(), Ordering.<String> natural().nullsLast())
+               .compare(left.getDescription(), right.getDescription(), Ordering.<String> natural().nullsLast())
+               .compare(left.getOperatingSystem().getName(), right.getOperatingSystem().getName(),
+                     Ordering.<String> natural().nullsLast())
+               .compare(left.getOperatingSystem().getVersion(), right.getOperatingSystem().getVersion(),
+                     Ordering.<String> natural().nullsLast())
+               .compare(left.getOperatingSystem().getDescription(), right.getOperatingSystem().getDescription(),
+                     Ordering.<String> natural().nullsLast())
+               .compare(left.getOperatingSystem().getArch(), right.getOperatingSystem().getArch(),
+                     Ordering.<String> natural().nullsLast()).result();
+      }
+   };
 
-    @VisibleForTesting
-    // non-static for logging
-    final Function<Iterable<? extends Image>, Image> imageChooserFromOrdering(final Ordering<Image> ordering) {
-        return new Function<Iterable<? extends Image>, Image>() {
-            @Override
-            public Image apply(Iterable<? extends Image> input) {
-                List<? extends Image> maxImages = multiMax(ordering, input);
-                if (logger.isTraceEnabled())
-                    logger.trace("<<   best images(%s)", transform(maxImages, imageToId));
-                return maxImages.get(maxImages.size() - 1);
-            }
-        };
-    }
+   @VisibleForTesting
+   // non-static for logging
+   final Function<Iterable<? extends Image>, Image> imageChooserFromOrdering(final Ordering<Image> ordering) {
+      return new Function<Iterable<? extends Image>, Image>() {
+         @Override
+         public Image apply(Iterable<? extends Image> input) {
+            List<? extends Image> maxImages = multiMax(ordering, input);
+            if (logger.isTraceEnabled())
+               logger.trace("<<   best images(%s)", transform(maxImages, imageToId));
+            return maxImages.get(maxImages.size() - 1);
+         }
+      };
+   }
 
-    @VisibleForTesting
-    Function<Iterable<? extends Image>, Image> defaultImageChooser() {
-        return imageChooserFromOrdering(DEFAULT_IMAGE_ORDERING);
-    }
+   @VisibleForTesting
+   Function<Iterable<? extends Image>, Image> defaultImageChooser() {
+       return imageChooserFromOrdering(DEFAULT_IMAGE_ORDERING);
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder fromTemplate(Template template) {
-        location = template.getLocation();
-        fromHardware(template.getHardware());
-        fromImage(template.getImage());
-        options(template.getOptions());
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder fromTemplate(Template template) {
+      location = template.getLocation();
+      fromHardware(template.getHardware());
+      fromImage(template.getImage());
+      options(template.getOptions());
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder fromHardware(Hardware hardware) {
-        if (currentLocationWiderThan(hardware.getLocation()))
-            this.location = hardware.getLocation();
-        this.minCores = getCores(hardware);
-        this.minRam = hardware.getRam();
-        this.minDisk = getSpace(hardware);
-        this.hypervisor = hardware.getHypervisor();
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder fromHardware(Hardware hardware) {
+      if (currentLocationWiderThan(hardware.getLocation()))
+         this.location = hardware.getLocation();
+      this.minCores = getCores(hardware);
+      this.minRam = hardware.getRam();
+      this.minDisk = getSpace(hardware);
+      this.hypervisor = hardware.getHypervisor();
+      return this;
+   }
 
-    private boolean currentLocationWiderThan(Location location) {
-        return this.location == null || (location != null && this.location.getScope().compareTo(location.getScope()) < 0);
-    }
+   private boolean currentLocationWiderThan(Location location) {
+      return this.location == null || (location != null && this.location.getScope().compareTo(location.getScope()) < 0);
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder fromImage(Image image) {
-        if (currentLocationWiderThan(image.getLocation()))
-            this.location = image.getLocation();
-        if (image.getOperatingSystem().getFamily() != null)
-            this.osFamily = image.getOperatingSystem().getFamily();
-        if (image.getName() != null)
-            this.imageName = image.getName();
-        if (image.getDescription() != null)
-            this.imageDescription = String.format("^%s$", Pattern.quote(image.getDescription()));
-        if (image.getOperatingSystem().getName() != null)
-            this.osName = image.getOperatingSystem().getName();
-        if (image.getOperatingSystem().getDescription() != null)
-            this.osDescription = image.getOperatingSystem().getDescription();
-        if (image.getVersion() != null)
-            this.imageVersion = String.format("^%s$", Pattern.quote(image.getVersion()));
-        if (image.getOperatingSystem().getVersion() != null)
-            this.osVersion = image.getOperatingSystem().getVersion();
-        this.os64Bit = image.getOperatingSystem().is64Bit();
-        if (image.getOperatingSystem().getArch() != null)
-            this.osArch = image.getOperatingSystem().getArch();
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder fromImage(Image image) {
+      if (currentLocationWiderThan(image.getLocation()))
+         this.location = image.getLocation();
+      if (image.getOperatingSystem().getFamily() != null)
+         this.osFamily = image.getOperatingSystem().getFamily();
+      if (image.getName() != null)
+         this.imageName = image.getName();
+      if (image.getDescription() != null)
+         this.imageDescription = String.format("^%s$", Pattern.quote(image.getDescription()));
+      if (image.getOperatingSystem().getName() != null)
+         this.osName = image.getOperatingSystem().getName();
+      if (image.getOperatingSystem().getDescription() != null)
+         this.osDescription = image.getOperatingSystem().getDescription();
+      if (image.getVersion() != null)
+         this.imageVersion = String.format("^%s$", Pattern.quote(image.getVersion()));
+      if (image.getOperatingSystem().getVersion() != null)
+         this.osVersion = image.getOperatingSystem().getVersion();
+      this.os64Bit = image.getOperatingSystem().is64Bit();
+      if (image.getOperatingSystem().getArch() != null)
+         this.osArch = image.getOperatingSystem().getArch();
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder smallest() {
-        this.biggest = false;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder smallest() {
+      this.biggest = false;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder biggest() {
-        this.biggest = true;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder biggest() {
+      this.biggest = true;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder fastest() {
-        this.fastest = true;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder fastest() {
+      this.fastest = true;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder locationId(final String locationId) {
-        Set<? extends Location> locations = this.locations.get();
-        try {
-            this.location = find(locations, new Predicate<Location>() {
-
-                @Override
-                public boolean apply(Location input) {
-                    return input.getId().equals(locationId);
-                }
-
-                @Override
-                public String toString() {
-                    return "locationId(" + locationId + ")";
-                }
-
-            });
-        } catch (NoSuchElementException e) {
-            throw new NoSuchElementException(format("location id %s not found in: %s", locationId, locations));
-        }
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder osFamily(OsFamily os) {
-        this.osFamily = os;
-        return this;
-    }
-
-    private static final Function<Image, String> imageToId = new Function<Image, String>() {
-
-        @Override
-        public String apply(Image arg0) {
-            return arg0.getId();
-        }
-
-    };
-
-
-    private static final Function<Hardware, String> hardwareToId = new Function<Hardware, String>() {
-
-        @Override
-        public String apply(Hardware arg0) {
-            return arg0.getId();
-        }
-
-    };
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Template build() {
-        if (nothingChangedExceptOptions()) {
-            TemplateBuilder defaultTemplate = defaultTemplateProvider.get();
-            if (options != null)
-                defaultTemplate.options(options);
-            return defaultTemplate.build();
-        }
-
-        if (options == null)
-            options = optionsProvider.get();
-        logger.debug(">> searching params(%s)", this);
-        Set<? extends Image> images = getImages();
-        checkState(!images.isEmpty(), "no images present!");
-        Set<? extends Hardware> hardwaresToSearch = hardwares.get();
-        checkState(!hardwaresToSearch.isEmpty(), "no hardware profiles present!");
-
-        Image image = null;
-        if (imageId != null) {
-            image = findImageWithId(images);
-            if (currentLocationWiderThan(image.getLocation()))
-                this.location = image.getLocation();
-        }
-
-        Hardware hardware = null;
-        if (hardwareId != null) {
-            hardware = findHardwareWithId(hardwaresToSearch);
-            if (currentLocationWiderThan(hardware.getLocation()))
-                this.location = hardware.getLocation();
-        }
-
-        // if the user hasn't specified a location id, or an image or hardware
-        // with location, let's search scoped to the implicit one
-        if (location == null)
-            location = defaultLocation.get();
-
-        if (image == null) {
-            Iterable<? extends Image> supportedImages = findSupportedImages(images);
-            if (hardware == null)
-                hardware = resolveHardware(hardwaresToSearch, supportedImages);
-            image = resolveImage(hardware, supportedImages);
-        } else {
-            if (hardware == null)
-                hardware = resolveHardware(hardwaresToSearch, ImmutableSet.of(image));
-        }
-
-        logger.debug("<<   matched image(%s) hardware(%s) location(%s)", image.getId(), hardware.getId(),
-                location.getId());
-        return new TemplateImpl(image, hardware, location, options);
-    }
-
-    private Iterable<? extends Image> findSupportedImages(Set<? extends Image> images) {
-        Predicate<Image> imagePredicate = buildImagePredicate();
-        Iterable<? extends Image> supportedImages = filter(images, imagePredicate);
-        if (size(supportedImages) == 0) {
-            throw throwNoSuchElementExceptionAfterLoggingImageIds(
-                    format("no image matched predicate: %s", imagePredicate), images);
-        }
-        return supportedImages;
-    }
-
-    private Image findImageWithId(Set<? extends Image> images) {
-        // Try to find the image in the cache and fallback to the GetImageStrategy
-        // see https://issues.apache.org/jira/browse/JCLOUDS-570
-        Optional<? extends Image> image = tryFind(images, idPredicate);
-        if (image.isPresent()) {
-            return image.get();
-        }
-
-        logger.info("Image %s not found in the image cache. Trying to get it from the provider...", imageId);
-        // Note that this will generate make a call to the provider instead of using a cache, but
-        // this will be executed rarely, only when an image is not present in the image list but
-        // it actually exists in the provider. It shouldn't be an expensive call so using a cache just for
-        // this corner case is overkill.
-        Image imageFromProvider = getImageStrategy.getImage(imageId);
-        if (imageFromProvider == null) {
-            throwNoSuchElementExceptionAfterLoggingImageIds(format("%s not found", idPredicate), images);
-        }
-        // Register the just found image in the image cache, so subsequent uses of the TemplateBuilder and
-        // the ComptueService find it.
-        this.images.registerImage(imageFromProvider);
-        return imageFromProvider;
-    }
-
-    private Hardware findHardwareWithId(Set<? extends Hardware> hardwaresToSearch) {
-        Hardware hardware;
-        // TODO: switch to GetHardwareStrategy in version 1.5
-        hardware = tryFind(hardwaresToSearch, hardwareIdPredicate).orNull();
-        if (hardware == null)
-            throw throwNoSuchElementExceptionAfterLoggingHardwareIds(format("%s not found", hardwareIdPredicate),
-                    hardwaresToSearch);
-        return hardware;
-    }
-
-    protected NoSuchElementException throwNoSuchElementExceptionAfterLoggingImageIds(String message, Iterable<? extends Image> images) {
-        NoSuchElementException exception = new NoSuchElementException(message);
-        if (logger.isTraceEnabled())
-            logger.warn(exception, "image ids that didn't match: %s", transform(images, imageToId));
-        throw exception;
-    }
-
-    protected NoSuchElementException throwNoSuchElementExceptionAfterLoggingHardwareIds(String message, Iterable<? extends Hardware> hardwares) {
-        NoSuchElementException exception = new NoSuchElementException(message);
-        if (logger.isTraceEnabled())
-            logger.warn(exception, "hardware ids that didn't match: %s", transform(hardwares, hardwareToId));
-        throw exception;
-    }
-
-    protected Hardware resolveHardware(Set<? extends Hardware> hardwarel, final Iterable<? extends Image> images) {
-        Ordering<Hardware> hardwareOrdering = hardwareSorter();
-
-        Iterable<Predicate<Image>> supportsImagePredicates = Iterables.transform(hardwarel,
-                new Function<Hardware, Predicate<Image>>() {
-
-                    @Override
-                    public Predicate<Image> apply(Hardware input) {
-                        return input.supportsImage();
-                    }
-
-                });
-
-        Predicate<Image> supportsImagePredicate = Iterables.size(supportsImagePredicates) == 1 ? Iterables
-                .getOnlyElement(supportsImagePredicates) : Predicates.<Image>or(supportsImagePredicates);
-
-        if (!Iterables.any(images, supportsImagePredicate)) {
-            String message = format("no hardware profiles support images matching params: %s", supportsImagePredicate);
-            throw throwNoSuchElementExceptionAfterLoggingHardwareIds(message, hardwarel);
-        }
-
-        Iterable<? extends Hardware> hardwareCompatibleWithOurImages = filter(hardwarel, supportsImagesPredicate(images));
-        Predicate<Hardware> hardwarePredicate = buildHardwarePredicate();
-        Hardware hardware;
-        try {
-            hardware = hardwareOrdering.max(filter(hardwareCompatibleWithOurImages, hardwarePredicate));
-        } catch (NoSuchElementException exception) {
-            String message = format("no hardware profiles match params: %s", hardwarePredicate);
-            throw throwNoSuchElementExceptionAfterLoggingHardwareIds(message, hardwareCompatibleWithOurImages);
-        }
-        logger.trace("<<   matched hardware(%s)", hardware.getId());
-        return hardware;
-    }
-
-    protected Function<Iterable<? extends Image>, Image> imageChooser() {
-        if (imageChooser != null) return imageChooser;
-        return defaultImageChooser();
-    }
-
-    protected Ordering<Hardware> hardwareSorter() {
-        Ordering<Hardware> hardwareOrdering = DEFAULT_SIZE_ORDERING;
-        if (!biggest)
-            hardwareOrdering = hardwareOrdering.reverse();
-        if (fastest)
-            hardwareOrdering = Ordering.compound(ImmutableList.of(BY_CORES_ORDERING, hardwareOrdering));
-        hardwareOrdering = Ordering.compound(ImmutableList.of(NOT_DEPRECATED_ORDERING, hardwareOrdering));
-        return hardwareOrdering;
-    }
-
-    /**
-     *
-     * @param hardware
-     * @param supportedImages
-     * @throws NoSuchElementException
-     *            if there's no image that matches the predicate
-     */
-    protected Image resolveImage(final Hardware hardware, Iterable<? extends Image> supportedImages) {
-        Predicate<Image> imagePredicate = new Predicate<Image>() {
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder locationId(final String locationId) {
+      Set<? extends Location> locations = this.locations.get();
+      try {
+         this.location = find(locations, new Predicate<Location>() {
 
             @Override
-            public boolean apply(Image arg0) {
-                return hardware.supportsImage().apply(arg0);
+            public boolean apply(Location input) {
+               return input.getId().equals(locationId);
             }
 
             @Override
             public String toString() {
-                return "hardware(" + hardware + ").supportsImage()";
+               return "locationId(" + locationId + ")";
             }
-        };
 
-        try {
-            Iterable<? extends Image> matchingImages = filter(supportedImages, imagePredicate);
-            if (logger.isTraceEnabled())
-                logger.trace("<<   matched images(%s)", transform(matchingImages, imageToId));
-            return imageChooser().apply(matchingImages);
-        } catch (NoSuchElementException exception) {
-            throwNoSuchElementExceptionAfterLoggingImageIds(format("no image matched params: %s", toString()),
-                    supportedImages);
-            assert false;
-            return null;
-        }
-    }
+         });
+      } catch (NoSuchElementException e) {
+         throw new NoSuchElementException(format("location id %s not found in: %s", locationId, locations));
+      }
+      return this;
+   }
 
-    /**
-     * Like Ordering, but handle the case where there are multiple valid maximums
-     */
-    @SuppressWarnings("unchecked")
-    @VisibleForTesting
-    static <T, E extends T> List<E> multiMax(Comparator<T> ordering, Iterable<E> iterable) {
-        Iterator<E> iterator = iterable.iterator();
-        List<E> maxes = newArrayList(iterator.next());
-        E maxSoFar = maxes.get(0);
-        while (iterator.hasNext()) {
-            E current = iterator.next();
-            int comparison = ordering.compare(maxSoFar, current);
-            if (comparison == 0) {
-                maxes.add(current);
-            } else if (comparison < 0) {
-                maxes = newArrayList(current);
-                maxSoFar = current;
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder osFamily(OsFamily os) {
+      this.osFamily = os;
+      return this;
+   }
+
+   private static final Function<Image, String> imageToId = new Function<Image, String>() {
+
+      @Override
+      public String apply(Image arg0) {
+         return arg0.getId();
+      }
+
+   };
+
+
+   private static final Function<Hardware, String> hardwareToId = new Function<Hardware, String>() {
+
+      @Override
+      public String apply(Hardware arg0) {
+         return arg0.getId();
+      }
+
+   };
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Template build() {
+      if (nothingChangedExceptOptions()) {
+         TemplateBuilder defaultTemplate = defaultTemplateProvider.get();
+         if (options != null)
+            defaultTemplate.options(options);
+         return defaultTemplate.build();
+      }
+
+      if (options == null)
+         options = optionsProvider.get();
+      logger.debug(">> searching params(%s)", this);
+      Set<? extends Image> images = getImages();
+      checkState(!images.isEmpty(), "no images present!");
+      Set<? extends Hardware> hardwaresToSearch = hardwares.get();
+      checkState(!hardwaresToSearch.isEmpty(), "no hardware profiles present!");
+
+      Image image = null;
+      if (imageId != null) {
+         image = loadImageWithId(images);
+         if (currentLocationWiderThan(image.getLocation()))
+            this.location = image.getLocation();
+      }
+
+      Hardware hardware = null;
+      if (hardwareId != null) {
+         hardware = findHardwareWithId(hardwaresToSearch);
+         if (currentLocationWiderThan(hardware.getLocation()))
+            this.location = hardware.getLocation();
+      }
+
+      // if the user hasn't specified a location id, or an image or hardware
+      // with location, let's search scoped to the implicit one
+      if (location == null)
+         location = defaultLocation.get();
+
+      if (image == null) {
+         Iterable<? extends Image> supportedImages = findSupportedImages(images);
+         if (hardware == null)
+            hardware = resolveHardware(hardwaresToSearch, supportedImages);
+         image = resolveImage(hardware, supportedImages);
+      } else {
+         if (hardware == null)
+            hardware = resolveHardware(hardwaresToSearch, ImmutableSet.of(image));
+      }
+
+      logger.debug("<<   matched image(%s) hardware(%s) location(%s)", image.getId(), hardware.getId(),
+            location.getId());
+      return new TemplateImpl(image, hardware, location, options);
+   }
+
+   private Iterable<? extends Image> findSupportedImages(Set<? extends Image> images) {
+      Predicate<Image> imagePredicate = buildImagePredicate();
+      Iterable<? extends Image> supportedImages = filter(images, imagePredicate);
+      if (size(supportedImages) == 0) {
+         throw throwNoSuchElementExceptionAfterLoggingImageIds(
+               format("no image matched predicate: %s", imagePredicate), images);
+      }
+      return supportedImages;
+   }
+
+   private Image loadImageWithId(Iterable<? extends Image> images) {
+      Optional<? extends Image> image = tryFind(images, ImagePredicates.idEquals(imageId));
+      if (!image.isPresent()) {
+         image = this.images.get(imageId); // Load the image from the cache, and refresh if missing
+         if (!image.isPresent()) {
+            throw throwNoSuchElementExceptionAfterLoggingImageIds(format("imageId(%s) not found", imageId), images);
+         }
+      }
+      fromImage(image.get());
+      return image.get();
+   }
+
+   protected Hardware findHardwareWithId(Set<? extends Hardware> hardwaresToSearch) {
+      Hardware hardware;
+      // TODO: switch to GetHardwareStrategy in version 1.5
+      hardware = tryFind(hardwaresToSearch, hardwareIdPredicate).orNull();
+      if (hardware == null)
+         throw throwNoSuchElementExceptionAfterLoggingHardwareIds(format("%s not found", hardwareIdPredicate),
+               hardwaresToSearch);
+      return hardware;
+   }
+
+   protected NoSuchElementException throwNoSuchElementExceptionAfterLoggingImageIds(String message, Iterable<? extends Image> images) {
+      NoSuchElementException exception = new NoSuchElementException(message);
+      if (logger.isTraceEnabled())
+         logger.warn(exception, "image ids that didn't match: %s", transform(images, imageToId));
+      throw exception;
+   }
+
+   protected NoSuchElementException throwNoSuchElementExceptionAfterLoggingHardwareIds(String message, Iterable<? extends Hardware> hardwares) {
+      NoSuchElementException exception = new NoSuchElementException(message);
+      if (logger.isTraceEnabled())
+         logger.warn(exception, "hardware ids that didn't match: %s", transform(hardwares, hardwareToId));
+      throw exception;
+   }
+
+   protected Hardware resolveHardware(Set<? extends Hardware> hardwarel, final Iterable<? extends Image> images) {
+      Ordering<Hardware> hardwareOrdering = hardwareSorter();
+
+      Iterable<Predicate<Image>> supportsImagePredicates = Iterables.transform(hardwarel,
+               new Function<Hardware, Predicate<Image>>() {
+
+                  @Override
+                  public Predicate<Image> apply(Hardware input) {
+                     return input.supportsImage();
+                  }
+
+               });
+
+      Predicate<Image> supportsImagePredicate = Iterables.size(supportsImagePredicates) == 1 ? Iterables
+               .getOnlyElement(supportsImagePredicates) : Predicates.<Image>or(supportsImagePredicates);
+
+      if (!Iterables.any(images, supportsImagePredicate)) {
+         String message = format("no hardware profiles support images matching params: %s", supportsImagePredicate);
+         throw throwNoSuchElementExceptionAfterLoggingHardwareIds(message, hardwarel);
+      }
+
+      Iterable<? extends Hardware> hardwareCompatibleWithOurImages = filter(hardwarel, supportsImagesPredicate(images));
+      Predicate<Hardware> hardwarePredicate = buildHardwarePredicate();
+      Hardware hardware;
+      try {
+         hardware = hardwareOrdering.max(filter(hardwareCompatibleWithOurImages, hardwarePredicate));
+      } catch (NoSuchElementException exception) {
+         String message = format("no hardware profiles match params: %s", hardwarePredicate);
+         throw throwNoSuchElementExceptionAfterLoggingHardwareIds(message, hardwareCompatibleWithOurImages);
+      }
+      logger.trace("<<   matched hardware(%s)", hardware.getId());
+      return hardware;
+   }
+
+   protected Function<Iterable<? extends Image>, Image> imageChooser() {
+      if (imageChooser != null) return imageChooser;
+      return defaultImageChooser();
+   }
+
+   protected Ordering<Hardware> hardwareSorter() {
+      Ordering<Hardware> hardwareOrdering = DEFAULT_SIZE_ORDERING;
+      if (!biggest)
+         hardwareOrdering = hardwareOrdering.reverse();
+      if (fastest)
+         hardwareOrdering = Ordering.compound(ImmutableList.of(BY_CORES_ORDERING, hardwareOrdering));
+      hardwareOrdering = Ordering.compound(ImmutableList.of(NOT_DEPRECATED_ORDERING, hardwareOrdering));
+      return hardwareOrdering;
+   }
+
+   /**
+    *
+    * @param hardware
+    * @param supportedImages
+    * @throws NoSuchElementException
+    *            if there's no image that matches the predicate
+    */
+   protected Image resolveImage(final Hardware hardware, Iterable<? extends Image> supportedImages) {
+      Predicate<Image> imagePredicate = new Predicate<Image>() {
+
+         @Override
+         public boolean apply(Image arg0) {
+            return hardware.supportsImage().apply(arg0);
+         }
+
+         @Override
+         public String toString() {
+            return "hardware(" + hardware + ").supportsImage()";
+         }
+      };
+
+      try {
+         Iterable<? extends Image> matchingImages = filter(supportedImages, imagePredicate);
+         if (logger.isTraceEnabled())
+            logger.trace("<<   matched images(%s)", transform(matchingImages, imageToId));
+         return imageChooser().apply(matchingImages);
+      } catch (NoSuchElementException exception) {
+         throw throwNoSuchElementExceptionAfterLoggingImageIds(format("no image matched params: %s", toString()),
+               supportedImages);
+      }
+   }
+
+   /**
+    * Like Ordering, but handle the case where there are multiple valid maximums
+    */
+   @SuppressWarnings("unchecked")
+   @VisibleForTesting
+   static <T, E extends T> List<E> multiMax(Comparator<T> ordering, Iterable<E> iterable) {
+      Iterator<E> iterator = iterable.iterator();
+      List<E> maxes = newArrayList(iterator.next());
+      E maxSoFar = maxes.get(0);
+      while (iterator.hasNext()) {
+         E current = iterator.next();
+         int comparison = ordering.compare(maxSoFar, current);
+         if (comparison == 0) {
+            maxes.add(current);
+         } else if (comparison < 0) {
+            maxes = newArrayList(current);
+            maxSoFar = current;
+         }
+      }
+      return maxes;
+   }
+   protected Set<? extends Image> getImages() {
+      return forceCacheReload != null && forceCacheReload ? images.rebuildCache() : images.get();
+   }
+
+   protected Predicate<Image> buildImagePredicate() {
+      List<Predicate<Image>> predicates = newArrayList();
+      if (location != null)
+         predicates.add(new Predicate<Image>() {
+
+            @Override
+            public boolean apply(Image input) {
+               return locationPredicate.apply(input);
             }
-        }
-        return maxes;
-    }
-    protected Set<? extends Image> getImages() {
-        return images.get();
-    }
 
-    protected Predicate<Image> buildImagePredicate() {
-        List<Predicate<Image>> predicates = newArrayList();
-        if (location != null)
-            predicates.add(new Predicate<Image>() {
+            @Override
+            public String toString() {
+               return locationPredicate.toString();
+            }
+         });
 
-                @Override
-                public boolean apply(Image input) {
-                    return locationPredicate.apply(input);
-                }
+      final List<Predicate<OperatingSystem>> osPredicates = newArrayList();
+      if (osFamily != null)
+         osPredicates.add(osFamilyPredicate);
+      if (osName != null)
+         osPredicates.add(osNamePredicate);
+      if (osDescription != null)
+         osPredicates.add(osDescriptionPredicate);
+      if (osVersion != null)
+         osPredicates.add(osVersionPredicate);
+      if (os64Bit != null)
+         osPredicates.add(os64BitPredicate);
+      if (osArch != null)
+         osPredicates.add(osArchPredicate);
+      if (!osPredicates.isEmpty())
+         predicates.add(new Predicate<Image>() {
 
-                @Override
-                public String toString() {
-                    return locationPredicate.toString();
-                }
-            });
+            @Override
+            public boolean apply(Image input) {
+               return and(osPredicates).apply(input.getOperatingSystem());
+            }
 
-        final List<Predicate<OperatingSystem>> osPredicates = newArrayList();
-        if (osFamily != null)
-            osPredicates.add(osFamilyPredicate);
-        if (osName != null)
-            osPredicates.add(osNamePredicate);
-        if (osDescription != null)
-            osPredicates.add(osDescriptionPredicate);
-        if (osVersion != null)
-            osPredicates.add(osVersionPredicate);
-        if (os64Bit != null)
-            osPredicates.add(os64BitPredicate);
-        if (osArch != null)
-            osPredicates.add(osArchPredicate);
-        if (!osPredicates.isEmpty())
-            predicates.add(new Predicate<Image>() {
+            @Override
+            public String toString() {
+               return and(osPredicates).toString();
+            }
 
-                @Override
-                public boolean apply(Image input) {
-                    return and(osPredicates).apply(input.getOperatingSystem());
-                }
+         });
+      if (imageVersion != null)
+         predicates.add(imageVersionPredicate);
+      if (imageName != null)
+         predicates.add(imageNamePredicate);
+      if (imageDescription != null)
+         predicates.add(imageDescriptionPredicate);
+      if (imagePredicate != null)
+         predicates.add(imagePredicate);
 
-                @Override
-                public String toString() {
-                    return and(osPredicates).toString();
-                }
+      // looks verbose, but explicit <Image> type needed for this to compile
+      // properly
+      Predicate<Image> imagePredicate = predicates.size() == 1 ? Iterables.<Predicate<Image>> get(predicates, 0)
+            : Predicates.<Image> and(predicates);
+      return imagePredicate;
+   }
 
-            });
-        if (imageVersion != null)
-            predicates.add(imageVersionPredicate);
-        if (imageName != null)
-            predicates.add(imageNamePredicate);
-        if (imageDescription != null)
-            predicates.add(imageDescriptionPredicate);
-        if (imagePredicate != null)
-            predicates.add(imagePredicate);
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder imageId(String imageId) {
+      this.imageId = imageId;
+      this.imageName = null;
+      this.imageDescription = null;
+      this.imagePredicate = null;
+      this.imageVersion = null;
+      this.osFamily = null;
+      this.osName = null;
+      this.osDescription = null;
+      this.osVersion = null;
+      this.os64Bit = null;
+      this.osArch = null;
+      return this;
+   }
 
-        // looks verbose, but explicit <Image> type needed for this to compile
-        // properly
-        Predicate<Image> imagePredicate = predicates.size() == 1 ? Iterables.<Predicate<Image>> get(predicates, 0)
-                : Predicates.<Image> and(predicates);
-        return imagePredicate;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder imageNameMatches(String nameRegex) {
+      this.imageName = nameRegex;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder imageId(String imageId) {
-        this.imageId = imageId;
-        this.imageName = null;
-        this.imageDescription = null;
-        this.imagePredicate = null;
-        this.imageVersion = null;
-        this.osFamily = null;
-        this.osName = null;
-        this.osDescription = null;
-        this.osVersion = null;
-        this.os64Bit = null;
-        this.osArch = null;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder imageDescriptionMatches(String descriptionRegex) {
+      this.imageDescription = descriptionRegex;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder imageNameMatches(String nameRegex) {
-        this.imageName = nameRegex;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder imageMatches(Predicate<Image> condition) {
+      this.imagePredicate = condition;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder imageDescriptionMatches(String descriptionRegex) {
-        this.imageDescription = descriptionRegex;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilderImpl imageChooser(Function<Iterable<? extends Image>, Image> imageChooser) {
+      this.imageChooser = imageChooser;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder imageMatches(Predicate<Image> condition) {
-        this.imagePredicate = condition;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder imageVersionMatches(String imageVersionRegex) {
+      this.imageVersion = imageVersionRegex;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilderImpl imageChooser(Function<Iterable<? extends Image>, Image> imageChooser) {
-        this.imageChooser = imageChooser;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder osVersionMatches(String osVersionRegex) {
+      this.osVersion = osVersionRegex;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder imageVersionMatches(String imageVersionRegex) {
-        this.imageVersion = imageVersionRegex;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder osArchMatches(String osArchitectureRegex) {
+      this.osArch = osArchitectureRegex;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder osVersionMatches(String osVersionRegex) {
-        this.osVersion = osVersionRegex;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder minCores(double minCores) {
+      this.minCores = minCores;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder osArchMatches(String osArchitectureRegex) {
-        this.osArch = osArchitectureRegex;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder minRam(int megabytes) {
+      this.minRam = megabytes;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder minCores(double minCores) {
-        this.minCores = minCores;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder minDisk(double gigabytes) {
+      this.minDisk = gigabytes;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder minRam(int megabytes) {
-        this.minRam = megabytes;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder osNameMatches(String osNameRegex) {
+      this.osName = osNameRegex;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder minDisk(double gigabytes) {
-        this.minDisk = gigabytes;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder osDescriptionMatches(String osDescriptionRegex) {
+      this.osDescription = osDescriptionRegex;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder osNameMatches(String osNameRegex) {
-        this.osName = osNameRegex;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder hardwareId(String hardwareId) {
+      this.hardwareId = hardwareId;
+      this.hypervisor = null;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder osDescriptionMatches(String osDescriptionRegex) {
-        this.osDescription = osDescriptionRegex;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder hypervisorMatches(String hypervisor) {
+      this.hypervisor = hypervisor;
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder hardwareId(String hardwareId) {
-        this.hardwareId = hardwareId;
-        this.hypervisor = null;
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder options(TemplateOptions options) {
+      this.options = optionsProvider.get();
+      checkNotNull(options, "options").copyTo(this.options);
+      return this;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder hypervisorMatches(String hypervisor) {
-        this.hypervisor = hypervisor;
-        return this;
-    }
+   @VisibleForTesting
+   boolean nothingChangedExceptOptions() {
+      return osFamily == null && location == null && imageId == null && hardwareId == null && hypervisor == null
+            && osName == null && imagePredicate == null && imageChooser == null && osDescription == null
+            && imageVersion == null && osVersion == null && osArch == null && os64Bit == null && imageName == null
+            && imageDescription == null && minCores == 0 && minRam == 0 && minDisk == 0 && !biggest && !fastest;
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder options(TemplateOptions options) {
-        this.options = optionsProvider.get();
-        checkNotNull(options, "options").copyTo(this.options);
-        return this;
-    }
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public TemplateBuilder any() {
+      return defaultTemplateProvider.get();
+   }
 
-    @VisibleForTesting
-    boolean nothingChangedExceptOptions() {
-        return osFamily == null && location == null && imageId == null && hardwareId == null && hypervisor == null
-                && osName == null && imagePredicate == null && imageChooser == null && osDescription == null
-                && imageVersion == null && osVersion == null && osArch == null && os64Bit == null && imageName == null
-                && imageDescription == null && minCores == 0 && minRam == 0 && minDisk == 0 && !biggest && !fastest;
-    }
+   @Override
+   public String toString() {
+      return string().toString();
+   }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TemplateBuilder any() {
-        return defaultTemplateProvider.get();
-    }
+   /**
+    * @since 1.5
+    */
+   protected ToStringHelper string() {
+      ToStringHelper toString = Objects.toStringHelper("").omitNullValues();
+      if (biggest)
+         toString.add("biggest", biggest);
+      if (fastest)
+         toString.add("fastest", fastest);
+      toString.add("imageName", imageName);
+      toString.add("imageDescription", imageDescription);
+      toString.add("imageId", imageId);
+      toString.add("imagePredicate", imagePredicate);
+      toString.add("imageChooser", imageChooser);
+      toString.add("imageVersion", imageVersion);
+      if (location != null)
+         toString.add("locationId", location.getId());
+      if (minCores > 0) //TODO: make non-primitive
+         toString.add("minCores", minCores);
+      if (minRam > 0) //TODO: make non-primitive
+         toString.add("minRam", minRam);
+      if (minRam > 0) //TODO: make non-primitive
+         toString.add("minRam", minRam);
+      if (minDisk > 0) //TODO: make non-primitive
+         toString.add("minDisk", minDisk);
+      toString.add("osFamily", osFamily);
+      toString.add("osName", osName);
+      toString.add("osDescription", osDescription);
+      toString.add("osVersion", osVersion);
+      toString.add("osArch", osArch);
+      toString.add("os64Bit", os64Bit);
+      toString.add("hardwareId", hardwareId);
+      toString.add("hypervisor", hypervisor);
+      toString.add("forceCacheReload", forceCacheReload);
+      return toString;
+   }
 
-    @Override
-    public String toString() {
-        return string().toString();
-    }
+   @Override
+   public TemplateBuilder os64Bit(boolean is64Bit) {
+      this.os64Bit = is64Bit;
+      return this;
+   }
 
-    /**
-     * @since 1.5
-     */
-    protected ToStringHelper string() {
-        ToStringHelper toString = Objects.toStringHelper("").omitNullValues();
-        if (biggest)
-            toString.add("biggest", biggest);
-        if (fastest)
-            toString.add("fastest", fastest);
-        toString.add("imageName", imageName);
-        toString.add("imageDescription", imageDescription);
-        toString.add("imageId", imageId);
-        toString.add("imagePredicate", imagePredicate);
-        toString.add("imageChooser", imageChooser);
-        toString.add("imageVersion", imageVersion);
-        if (location != null)
-            toString.add("locationId", location.getId());
-        if (minCores > 0) //TODO: make non-primitive
-            toString.add("minCores", minCores);
-        if (minRam > 0) //TODO: make non-primitive
-            toString.add("minRam", minRam);
-        if (minRam > 0) //TODO: make non-primitive
-            toString.add("minRam", minRam);
-        if (minDisk > 0) //TODO: make non-primitive
-            toString.add("minDisk", minDisk);
-        toString.add("osFamily", osFamily);
-        toString.add("osName", osName);
-        toString.add("osDescription", osDescription);
-        toString.add("osVersion", osVersion);
-        toString.add("osArch", osArch);
-        toString.add("os64Bit", os64Bit);
-        toString.add("hardwareId", hardwareId);
-        toString.add("hypervisor", hypervisor);
-        return toString;
-    }
+   @Override
+   public TemplateBuilder from(TemplateBuilderSpec spec) {
+      return spec.copyTo(this, options != null ? options : (options = optionsProvider.get()));
+   }
 
-    @Override
-    public TemplateBuilder os64Bit(boolean is64Bit) {
-        this.os64Bit = is64Bit;
-        return this;
-    }
+   @Override
+   public TemplateBuilder from(String spec) {
+      return from(TemplateBuilderSpec.parse(spec));
+   }
 
-    @Override
-    public TemplateBuilder from(TemplateBuilderSpec spec) {
-        return spec.copyTo(this, options != null ? options : (options = optionsProvider.get()));
-    }
+   @Override
+   public TemplateBuilder forceCacheReload() {
+      this.forceCacheReload = true;
+      return this;
+   }
 
-    @Override
-    public TemplateBuilder from(String spec) {
-        return from(TemplateBuilderSpec.parse(spec));
-    }
-
+   
 }

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/builders/TemplateBuilderImpl.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/builders/TemplateBuilderImpl.java
@@ -109,6 +109,7 @@ import static org.jclouds.compute.util.ComputeServiceUtils.getSpace;
  *   <li>{@code NullEqualToIsParentOrIsGrandparentOfCurrentLocation}
  *   <li>{@code TemplateImpl}
  * </ul>
+ * Adds <pre>{@code @Override}</pre> (to avoid errors from http://errorprone.info/bugpattern/MissingOverride).
  */
 public class TemplateBuilderImpl implements TemplateBuilder {
    @Resource
@@ -490,23 +491,27 @@ public class TemplateBuilderImpl implements TemplateBuilder {
    }
 
    static final Ordering<Hardware> DEFAULT_SIZE_ORDERING = new Ordering<Hardware>() {
+      @Override
       public int compare(Hardware left, Hardware right) {
          return ComparisonChain.start().compare(getCores(left), getCores(right)).compare(left.getRam(), right.getRam())
                .compare(getSpace(left), getSpace(right)).result();
       }
    };
    static final Ordering<Hardware> BY_CORES_ORDERING = new Ordering<Hardware>() {
+      @Override
       public int compare(Hardware left, Hardware right) {
          return Doubles.compare(getCoresAndSpeed(left), getCoresAndSpeed(right));
       }
    };
    static final Ordering<Hardware> NOT_DEPRECATED_ORDERING = new Ordering<Hardware>() {
+      @Override
       public int compare(Hardware left, Hardware right) {
          // we take max so deprecated items come first
          return ComparisonChain.start().compareTrueFirst(left.isDeprecated(), right.isDeprecated()).result();
       }
    };
    static final Ordering<Image> DEFAULT_IMAGE_ORDERING = new Ordering<Image>() {
+      @Override
       public int compare(Image left, Image right) {
          /* This currently, and for some time, has *preferred* images whose fields are null,
           * and prefers those which come last alphabetically.

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/builders/VCloudDirectorTemplateBuilderImpl.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/builders/VCloudDirectorTemplateBuilderImpl.java
@@ -16,33 +16,36 @@
  */
 package org.jclouds.vcloud.director.v1_5.builders;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.base.Supplier;
-import com.google.common.collect.Iterables;
-import com.google.inject.Inject;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Lists.newArrayList;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Named;
+import javax.inject.Provider;
+
 import org.jclouds.collect.Memoized;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.Image;
 import org.jclouds.compute.domain.OperatingSystem;
 import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.options.TemplateOptions;
-import org.jclouds.compute.strategy.GetImageStrategy;
-import org.jclouds.compute.suppliers.ImageCacheSupplier;
 import org.jclouds.domain.Location;
 
-import javax.inject.Named;
-import javax.inject.Provider;
-import java.util.List;
-import java.util.Set;
-
-import static com.google.common.base.Predicates.and;
-import static com.google.common.collect.Lists.newArrayList;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Iterables;
+import com.google.inject.Inject;
 
 public class VCloudDirectorTemplateBuilderImpl extends TemplateBuilderImpl {
     @Inject
-    protected VCloudDirectorTemplateBuilderImpl(@Memoized Supplier<Set<? extends Location>> locations, ImageCacheSupplier images, @Memoized Supplier<Set<? extends Hardware>> hardwares, Supplier<Location> defaultLocation, @Named("DEFAULT") Provider<TemplateOptions> optionsProvider, @Named("DEFAULT") Provider<TemplateBuilder> defaultTemplateProvider, GetImageStrategy getImageStrategy) {
-        super(locations, images, hardwares, defaultLocation, optionsProvider, defaultTemplateProvider, getImageStrategy);
+    protected VCloudDirectorTemplateBuilderImpl(@Memoized Supplier<Set<? extends Location>> locations,
+            @Memoized Supplier<Set<? extends Image>> images, @Memoized Supplier<Set<? extends Hardware>> hardwares,
+            Supplier<Location> defaultLocation, @Named("DEFAULT") Provider<TemplateOptions> optionsProvider,
+            @Named("DEFAULT") Provider<TemplateBuilder> defaultTemplateProvider) {
+        super(locations, images, hardwares, defaultLocation, optionsProvider, defaultTemplateProvider);
     }
 
     /**

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/FindLocationForResource.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/FindLocationForResource.java
@@ -51,6 +51,7 @@ public class FindLocationForResource implements Function<Reference, Location> {
     * @throws NoSuchElementException
     *            if not found
     */
+   @Override
    public Location apply(Reference resource) {
       for (Location input : locations.get()) {
          do {

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/HardwareForVm.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/HardwareForVm.java
@@ -58,10 +58,8 @@ public class HardwareForVm implements Function<Vm, Hardware> {
 
    @Override
    public Hardware apply(Vm from) {
-      checkNotNull(from, "VApp");
+      checkNotNull(from, "VM");
       // TODO make this work with composite vApps
-      if (from == null)
-         return null;
 
       VirtualHardwareSection hardware = findVirtualHardwareSectionForVm.apply(from);
       HardwareBuilder builder = rasdToHardwareBuilder.apply(hardware.getItems());

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/VmToNodeMetadata.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/functions/VmToNodeMetadata.java
@@ -74,6 +74,7 @@ public class VmToNodeMetadata implements Function<Vm, NodeMetadata> {
       this.api = api;
    }
 
+   @Override
    public NodeMetadata apply(Vm from) {
       NodeMetadataBuilder builder = new NodeMetadataBuilder();
       builder.ids(from.getId());

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapter.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapter.java
@@ -17,7 +17,6 @@
 package org.jclouds.vcloud.director.v1_5.compute.strategy;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.find;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -380,7 +379,7 @@ public class VCloudDirectorComputeServiceAdapter implements
    private VirtualHardwareSection updateVirtualHardwareSection(VirtualHardwareSection virtualHardwareSection, Predicate<ResourceAllocationSettingData>
             predicate, Function<ResourceAllocationSettingData, ResourceAllocationSettingData> modifier) {
       Set<? extends ResourceAllocationSettingData> oldItems = virtualHardwareSection.getItems();
-      Set<ResourceAllocationSettingData> newItems = Sets.newLinkedHashSet(oldItems);
+      Set<ResourceAllocationSettingData> newItems = Sets.<ResourceAllocationSettingData>newLinkedHashSet(oldItems);
       Optional<? extends ResourceAllocationSettingData> oldResourceAllocationSettingData = Iterables.tryFind(oldItems, predicate);
       if (oldResourceAllocationSettingData.isPresent()) {
          ResourceAllocationSettingData newResourceAllocationSettingData = modifier.apply(oldResourceAllocationSettingData.get());
@@ -676,16 +675,21 @@ public class VCloudDirectorComputeServiceAdapter implements
    }
 
    private Set<Vm> getAvailableVMsFromVAppTemplate(VAppTemplate vAppTemplate) {
-      return ImmutableSet.copyOf(filter(vAppTemplate.getChildren(), new Predicate<Vm>() {
-         // filter out vms in the vApp template with computer name that contains underscores, dots,
-         // or both.
-         @Override
-         public boolean apply(Vm input) {
-            GuestCustomizationSection guestCustomizationSection = api.getVmApi().getGuestCustomizationSection(input.getId());
-            String computerName = guestCustomizationSection.getComputerName();
-            return computerName.equals(computerName);
-         }
-      }));
+      // FIXME What should this be? Previously it did `computerName.equals(computerName)`,
+      // so would never have filtered anything out of the vApp children. Disabling for now.
+      // Old code was:
+//      return ImmutableSet.copyOf(filter(vAppTemplate.getChildren(), new Predicate<Vm>() {
+//         // filter out vms in the vApp template with computer name that contains underscores, dots,
+//         // or both.
+//         @Override
+//         public boolean apply(Vm input) {
+//            GuestCustomizationSection guestCustomizationSection = api.getVmApi().getGuestCustomizationSection(input.getId());
+//            String computerName = guestCustomizationSection.getComputerName();
+//            return computerName.equals(computerName);
+//         }
+//      }));
+      
+      return ImmutableSet.copyOf(vAppTemplate.getChildren());
    }
 
    private Org getOrgForSession() {

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapter.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapter.java
@@ -675,20 +675,6 @@ public class VCloudDirectorComputeServiceAdapter implements
    }
 
    private Set<Vm> getAvailableVMsFromVAppTemplate(VAppTemplate vAppTemplate) {
-      // FIXME What should this be? Previously it did `computerName.equals(computerName)`,
-      // so would never have filtered anything out of the vApp children. Disabling for now.
-      // Old code was:
-//      return ImmutableSet.copyOf(filter(vAppTemplate.getChildren(), new Predicate<Vm>() {
-//         // filter out vms in the vApp template with computer name that contains underscores, dots,
-//         // or both.
-//         @Override
-//         public boolean apply(Vm input) {
-//            GuestCustomizationSection guestCustomizationSection = api.getVmApi().getGuestCustomizationSection(input.getId());
-//            String computerName = guestCustomizationSection.getComputerName();
-//            return computerName.equals(computerName);
-//         }
-//      }));
-      
       return ImmutableSet.copyOf(vAppTemplate.getChildren());
    }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VcloudDirectorAdaptingComputeServiceStrategies.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VcloudDirectorAdaptingComputeServiceStrategies.java
@@ -24,7 +24,6 @@ import javax.annotation.Resource;
 
 import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.config.ComputeServiceAdapterContextModule.AddDefaultCredentialsToImage;
-import org.jclouds.compute.domain.ComputeMetadata;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.Image;
 import org.jclouds.compute.domain.NodeMetadata;
@@ -94,7 +93,7 @@ public class VcloudDirectorAdaptingComputeServiceStrategies extends AdaptingComp
    };
 
    @Override
-   public Iterable<? extends NodeMetadata> listDetailsOnNodesMatching(Predicate<ComputeMetadata> filter) {
+   public Iterable<? extends NodeMetadata> listDetailsOnNodesMatching(Predicate<? super NodeMetadata> filter) {
       return FluentIterable.from(client.listNodes())
                .transform(nodeMetadataAdapter)
                .filter(Predicates.notNull())

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/AbstractVAppType.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/AbstractVAppType.java
@@ -110,7 +110,7 @@ public abstract class AbstractVAppType extends ResourceEntity {
        * @see AbstractVAppType#getSections()
        */
       public B sections(Iterable<? extends SectionType> sections) {
-         this.sections = Sets.newLinkedHashSet(checkNotNull(sections, "sections"));
+         this.sections = Sets.<SectionType>newLinkedHashSet(checkNotNull(sections, "sections"));
          return self();
       }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/Error.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/Error.java
@@ -68,7 +68,7 @@ public class Error {
       @XmlEnumValue("503") UNAVAILABLE(503),
       UNRECOGNIZED(-1);
 
-      private Integer majorErrorCode;
+      private final Integer majorErrorCode;
       
       private Code(Integer majorErrorCode) {
          this.majorErrorCode = majorErrorCode;

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ResourceEntity.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/ResourceEntity.java
@@ -69,11 +69,11 @@ public abstract class ResourceEntity extends Entity {
       // Convention is "UNRECOGNIZED", but that is already a valid state name! so using UNRECOGNIZED_VALUE
       @XmlEnumValue("65535") UNRECOGNIZED_VALUE(65535, "Unrecognized", false, false, false);
       
-      private Integer value;
-      private String description;
-      private boolean vAppTemplate;
-      private boolean vApp;
-      private boolean vm;
+      private final Integer value;
+      private final String description;
+      private final boolean vAppTemplate;
+      private final boolean vApp;
+      private final boolean vm;
       
       private Status(int value, String description, boolean vAppTemplate, boolean vApp, boolean vm) {
          this.value = value;

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/VAppTemplate.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/VAppTemplate.java
@@ -98,7 +98,7 @@ public class VAppTemplate extends ResourceEntity {
        * @see VAppTemplate#getSections()
        */
       public B sections(Iterable<? extends SectionType> sections) {
-         this.sections = Sets.newLinkedHashSet(checkNotNull(sections, "sections"));
+         this.sections = Sets.<SectionType>newLinkedHashSet(checkNotNull(sections, "sections"));
          return self();
       }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/VirtualSystem.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/VirtualSystem.java
@@ -136,7 +136,7 @@ public class VirtualSystem extends SectionType {
       }
 
       public B virtualHardwareSections(Iterable<? extends VirtualHardwareSection> virtualHardwareSections) {
-         this.virtualHardwareSections = Sets.newLinkedHashSet(checkNotNull(virtualHardwareSections, "virtualHardwareSections"));
+         this.virtualHardwareSections = Sets.<VirtualHardwareSection>newLinkedHashSet(checkNotNull(virtualHardwareSections, "virtualHardwareSections"));
          return self();
       }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/ResourceType.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/ResourceType.java
@@ -40,7 +40,7 @@ public class ResourceType extends VCloudExtensibleType {
   public List<LinkType> getLink()
   {
     if (this.link == null) {
-      this.link = new ArrayList();
+      this.link = new ArrayList<LinkType>();
     }
     return this.link;
   }

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/VCloudExtensibleType.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/VCloudExtensibleType.java
@@ -36,12 +36,12 @@ public abstract class VCloudExtensibleType
   protected List<VCloudExtensionType> vCloudExtension;
 
   @XmlAnyAttribute
-  private Map<QName, String> otherAttributes = new HashMap();
+  private Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
   public List<VCloudExtensionType> getVCloudExtension()
   {
     if (this.vCloudExtension == null) {
-      this.vCloudExtension = new ArrayList();
+      this.vCloudExtension = new ArrayList<VCloudExtensionType>();
     }
     return this.vCloudExtension;
   }

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/VCloudExtensionType.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/VCloudExtensionType.java
@@ -40,12 +40,12 @@ public class VCloudExtensionType
   protected Boolean required;
 
   @XmlAnyAttribute
-  private Map<QName, String> otherAttributes = new HashMap();
+  private Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
   public List<Object> getAny()
   {
     if (this.any == null) {
-      this.any = new ArrayList();
+      this.any = new ArrayList<Object>();
     }
     return this.any;
   }

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/VirtualHardwareSection.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/VirtualHardwareSection.java
@@ -105,7 +105,7 @@ public class VirtualHardwareSection extends SectionType {
        * @see org.jclouds.vcloud.director.v1_5.domain.dmtf.ovf.VirtualHardwareSection#getItems()
        */
       public B items(Iterable<? extends ResourceAllocationSettingData> items) {
-         this.items = Sets.newLinkedHashSet(checkNotNull(items, "items"));
+         this.items = Sets.<ResourceAllocationSettingData>newLinkedHashSet(checkNotNull(items, "items"));
          return self();
       }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/internal/BaseVirtualSystem.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/dmtf/ovf/internal/BaseVirtualSystem.java
@@ -96,7 +96,7 @@ public abstract class BaseVirtualSystem extends SectionType {
        * @see org.jclouds.vcloud.director.v1_5.domain.dmtf.ovf.internal.BaseVirtualSystem#getAdditionalSections()
        */
       public B additionalSections(Iterable<? extends SectionType> additionalSections) {
-         this.additionalSections = Sets.newLinkedHashSet(checkNotNull(additionalSections, "additionalSections"));
+         this.additionalSections = Sets.<SectionType>newLinkedHashSet(checkNotNull(additionalSections, "additionalSections"));
          return self();
       }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/network/NetworkFeatures.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/network/NetworkFeatures.java
@@ -52,7 +52,7 @@ public class NetworkFeatures {
        * @see NetworkFeatures#getNetworkServices()
        */
       public Builder services(Set<? extends NetworkServiceType<?>> services) {
-         this.services = Sets.newLinkedHashSet(checkNotNull(services, "services"));
+         this.services = Sets.<NetworkServiceType<?>>newLinkedHashSet(checkNotNull(services, "services"));
          return this;
       }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/params/CaptureVAppParams.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/params/CaptureVAppParams.java
@@ -120,7 +120,7 @@ public class CaptureVAppParams extends ParamsType {
        * @see CaptureVAppParams#getSections()
        */
       public B sections(Iterable<? extends SectionType> sections) {
-         this.sections = Sets.newLinkedHashSet(checkNotNull(sections, "sections"));
+         this.sections = Sets.<SectionType>newLinkedHashSet(checkNotNull(sections, "sections"));
          return self();
       }
 
@@ -147,7 +147,7 @@ public class CaptureVAppParams extends ParamsType {
    }
 
    private CaptureVAppParams(Set<? extends SectionType> sections) {
-      this.sections = ImmutableSet.copyOf(sections);
+      this.sections = ImmutableSet.<SectionType>copyOf(sections);
    }
 
    @XmlElement(name = "Source", required = true)

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/params/InstantiationParams.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/params/InstantiationParams.java
@@ -72,7 +72,7 @@ public class InstantiationParams {
        * @see InstantiationParams#getSections()
        */
       public Builder sections(Iterable<? extends SectionType> sections) {
-         this.sections = Sets.newLinkedHashSet(checkNotNull(sections, "sections"));
+         this.sections = Sets.<SectionType>newLinkedHashSet(checkNotNull(sections, "sections"));
          return this;
       }
 
@@ -99,7 +99,7 @@ public class InstantiationParams {
    }
 
    private InstantiationParams(Set<? extends SectionType> sections) {
-      this.sections = sections.isEmpty() ? null : ImmutableSet.copyOf(sections);
+      this.sections = sections.isEmpty() ? null : ImmutableSet.<SectionType>copyOf(sections);
    }
 
    @XmlElementRefs({

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/domain/query/QueryResultReferences.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/domain/query/QueryResultReferences.java
@@ -62,7 +62,7 @@ public class QueryResultReferences extends ContainerType {
        * @see QueryResultReferences#getReferences()
        */
       public B references(Set<? extends Reference> references) {
-         this.references = Sets.newLinkedHashSet(checkNotNull(references, "references"));
+         this.references = Sets.<Reference>newLinkedHashSet(checkNotNull(references, "references"));
          return self();
       }
 

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminNetworkApi.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminNetworkApi.java
@@ -16,7 +16,6 @@
  */
 package org.jclouds.vcloud.director.v1_5.features.admin;
 
-import static org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType.ADMIN_ORG_NETWORK;
 import static org.jclouds.vcloud.director.v1_5.VCloudDirectorMediaType.TASK;
 
@@ -29,6 +28,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
+import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.EndpointParam;
 import org.jclouds.rest.annotations.Fallback;

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/functions/AddScsiLogicSASBus.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/functions/AddScsiLogicSASBus.java
@@ -27,6 +27,7 @@ import org.jclouds.vcloud.director.v1_5.domain.dmtf.cim.ResourceAllocationSettin
 
 public class AddScsiLogicSASBus {
     static final Ordering<RasdItem> BY_ADDRESS_ORDERING = new Ordering<RasdItem>() {
+        @Override
         public int compare(RasdItem left, RasdItem right) {
             if (left.getAddress() == null) {
                 return -1;

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/functions/NetworkSectionForVAppTemplate.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/functions/NetworkSectionForVAppTemplate.java
@@ -26,7 +26,6 @@ import com.google.common.base.Function;
 @Singleton
 public class NetworkSectionForVAppTemplate implements Function<VAppTemplate, NetworkSection> {
 
-   @SuppressWarnings("unchecked")
    @Override
    public NetworkSection apply(VAppTemplate from) {
       for (SectionType section : from.getSections()) {

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/functions/NewScsiLogicSASDisk.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/functions/NewScsiLogicSASDisk.java
@@ -16,22 +16,21 @@
  */
 package org.jclouds.vcloud.director.v1_5.functions;
 
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-//import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
+import javax.inject.Singleton;
+import javax.xml.namespace.QName;
+
 import org.jclouds.vcloud.director.v1_5.domain.RasdItemsList;
 import org.jclouds.vcloud.director.v1_5.domain.dmtf.RasdItem;
 import org.jclouds.vcloud.director.v1_5.domain.dmtf.cim.CimString;
 import org.jclouds.vcloud.director.v1_5.domain.dmtf.cim.ResourceAllocationSettingData;
+import org.jclouds.vcloud.director.v1_5.domain.dmtf.cim.ResourceAllocationSettingData.ResourceType;
 
-import javax.inject.Singleton;
-import javax.xml.namespace.QName;
-
-import static org.jclouds.vcloud.director.v1_5.domain.dmtf.cim.ResourceAllocationSettingData.ResourceType;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
 
 /**
  * Creates the next unique HDD RasdItem from RasdItemList.
@@ -47,6 +46,7 @@ public final class NewScsiLogicSASDisk implements Function<RasdItemsList, RasdIt
     };
 
     static final Ordering<RasdItem> BY_ADDRESS_ON_PARENT_ORDERING = new Ordering<RasdItem>() {
+        @Override
         public int compare(RasdItem left, RasdItem right) {
             if (left.getAddressOnParent() == null) {
                 return -1;

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/functions/VirtualHardwareSectionForVApp.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/functions/VirtualHardwareSectionForVApp.java
@@ -26,7 +26,6 @@ import com.google.inject.Singleton;
 @Singleton
 public class VirtualHardwareSectionForVApp implements Function<AbstractVAppType, VirtualHardwareSection> {
 
-   @SuppressWarnings("unchecked")
    @Override
    public VirtualHardwareSection apply(AbstractVAppType from) {
       for (SectionType section : from.getSections()) {

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/handlers/VCloudDirectorErrorHandler.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/handlers/VCloudDirectorErrorHandler.java
@@ -19,6 +19,8 @@ package org.jclouds.vcloud.director.v1_5.handlers;
 import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
 import javax.inject.Singleton;
 import javax.xml.bind.JAXB;
 
@@ -47,7 +49,7 @@ public class VCloudDirectorErrorHandler implements HttpErrorHandler {
 
       // Create default exception
       String message = data != null
-            ? new String(data)
+            ? new String(data, StandardCharsets.UTF_8)
             : String.format("%s -> %s", command.getCurrentRequest().getRequestLine(), response.getStatusLine());
       Exception exception = new HttpResponseException(command, response, message);
       

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/handlers/VcloudDirectorClientErrorRetryHandler.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/handlers/VcloudDirectorClientErrorRetryHandler.java
@@ -66,6 +66,6 @@ public class VcloudDirectorClientErrorRetryHandler extends BackoffLimitedRetryHa
 
    @Override
    public void imposeBackoffExponentialDelay(long period, int pow, int failureCount, int max, String commandDescription) {
-      imposeBackoffExponentialDelay(period, period * 100l, pow, failureCount, max, commandDescription);
+      imposeBackoffExponentialDelay(period, period * 100L, pow, failureCount, max, commandDescription);
    }
 }

--- a/src/main/java/org/jclouds/vcloud/director/v1_5/predicates/LinkPredicates.java
+++ b/src/main/java/org/jclouds/vcloud/director/v1_5/predicates/LinkPredicates.java
@@ -53,6 +53,7 @@ public class LinkPredicates {
       .maximumSize(Link.Rel.ALL.size())
       .build(
          new CacheLoader<Link.Rel, Predicate<Link>>() {
+            @Override
             public Predicate<Link> load(final Link.Rel rel) {
                return new Predicate<Link>() {
                   @Override
@@ -79,6 +80,7 @@ public class LinkPredicates {
       .maximumSize(VCloudDirectorMediaType.ALL.size())
       .build(
          new CacheLoader<String, Predicate<Link>>() {
+            @Override
             public Predicate<Link> load(String key) {
                return ReferencePredicates.nameEquals(key);
             }
@@ -95,6 +97,7 @@ public class LinkPredicates {
       .maximumSize(VCloudDirectorMediaType.ALL.size())
       .build(
          new CacheLoader<String, Predicate<Link>>() {
+            @Override
             public Predicate<Link> load(String key) {
                return ReferencePredicates.typeEquals(key);
             }

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapterLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/compute/strategy/VCloudDirectorComputeServiceAdapterLiveTest.java
@@ -83,6 +83,7 @@ public class VCloudDirectorComputeServiceAdapterLiveTest extends BaseVCloudDirec
    }
 
    @AfterGroups(groups = "live")
+   @Override
    protected void tearDown() {
       if (guest != null) {
          adapter.destroyNode(guest.getNode().getId());

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/domain/Checks.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/domain/Checks.java
@@ -132,7 +132,7 @@ public class Checks {
       // Check optional fields
       // NOTE description cannot be checked
       List<Task> tasks = entity.getTasks();
-      if (tasks != null && tasks != null && !tasks.isEmpty()) {
+      if (tasks != null && !tasks.isEmpty()) {
          for (Task task : tasks) checkTask(task);
       }
       
@@ -480,7 +480,7 @@ public class Checks {
       checkIpAddress(routerInfo.getExternalIp());
    }
    
-   public static void checkNetworkService(NetworkServiceType service) {
+   public static void checkNetworkService(NetworkServiceType<?> service) {
       // NOTE isEnabled cannot be checked
    }
    
@@ -895,12 +895,12 @@ public class Checks {
       assertTrue(settings.getPort() >= 0,
             String.format(OBJ_FIELD_GTE_0, "CustomOrgLdapSettings", "port", settings.getPort()));
       assertNotNull(settings.getAuthenticationMechanism(), String.format(OBJ_FIELD_REQ, "CustomOrgLdapSettings", "authenticationMechanism"));
-      assertTrue(AuthenticationMechanism.ALL.contains(settings.getAuthenticationMechanism()),
+      assertTrue(AuthenticationMechanism.ALL.contains(AuthenticationMechanism.valueOf(settings.getAuthenticationMechanism())),
             String.format(REQUIRED_VALUE_OBJECT_FMT, "AuthenticationMechanism", "CustomOrdLdapSettings", settings.getAuthenticationMechanism(),
                   Iterables.toString(CustomOrgLdapSettings.AuthenticationMechanism.ALL)));
       assertNotNull(settings.isGroupSearchBaseEnabled(), String.format(OBJ_FIELD_REQ, "CustomOrgLdapSettings", "isGroupSearchBaseEnabled"));
       assertNotNull(settings.getConnectorType(), String.format(OBJ_FIELD_REQ, "CustomOrgLdapSettings", "connectorType"));
-      assertTrue(ConnectorType.ALL.contains(settings.getConnectorType()),
+      assertTrue(ConnectorType.ALL.contains(ConnectorType.valueOf(settings.getConnectorType())),
             String.format(REQUIRED_VALUE_OBJECT_FMT, "ConnectorType", "CustomOrdLdapSettings", settings.getConnectorType(),
                   Iterables.toString(CustomOrgLdapSettings.ConnectorType.ALL)));
       assertNotNull(settings.getUserAttributes(), String.format(OBJ_FIELD_REQ, "CustomOrgLdapSettings", "userAttributes"));

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/features/ExponentialBackoffLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/features/ExponentialBackoffLiveTest.java
@@ -83,6 +83,7 @@ public class ExponentialBackoffLiveTest extends BaseVCloudDirectorApiLiveTest {
       List<ListenableFuture<?>> futures = Lists.newArrayList();
       for (int i = 0; i < numRuns; i++) {
          futures.add(executor.submit(new Runnable() {
+            @Override
             public void run() {
                api.getVdcApi().get(vdcUrn);
             }}));
@@ -105,6 +106,7 @@ public class ExponentialBackoffLiveTest extends BaseVCloudDirectorApiLiveTest {
       List<ListenableFuture<?>> futures = Lists.newArrayList();
       for (int i = 0; i < numRuns; i++) {
          futures.add(executor.submit(new Callable<Object>() {
+            @Override
             public Object call() {
                String name = name("composed-");
 

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppApiLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/features/VAppApiLiveTest.java
@@ -848,7 +848,7 @@ public class VAppApiLiveTest extends AbstractVAppApiLiveTest {
                .sourcedItems(ImmutableList.of(vmItem)).build();
    }
    
-   private final class IsVAppNetworkNamed implements Predicate<VAppNetworkConfiguration> {
+   private static final class IsVAppNetworkNamed implements Predicate<VAppNetworkConfiguration> {
       private final String networkName;
 
       private IsVAppNetworkNamed(String networkName) {

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/features/VmApiLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/features/VmApiLiveTest.java
@@ -611,7 +611,7 @@ public class VmApiLiveTest extends AbstractVAppApiLiveTest {
       // Copy existing section and edit fields
       VirtualHardwareSection oldSection = vmApi.getVirtualHardwareSection(vmUrn);
       Set<? extends ResourceAllocationSettingData> oldItems = oldSection.getItems();
-      Set<ResourceAllocationSettingData> newItems = Sets.newLinkedHashSet(oldItems);
+      Set<ResourceAllocationSettingData> newItems = Sets.<ResourceAllocationSettingData>newLinkedHashSet(oldItems);
       ResourceAllocationSettingData oldMemory = Iterables.find(oldItems,
                new Predicate<ResourceAllocationSettingData>() {
                   @Override

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminOrgApiLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminOrgApiLiveTest.java
@@ -316,7 +316,7 @@ public class AdminOrgApiLiveTest extends BaseVCloudDirectorApiLiveTest {
    @Test(description = "PUT /admin/org/{id}/settings", dependsOnMethods = { "testGetEmailSettings" })
    public void testEditSettings() throws Exception {
       String newFromEmailAddress = "test" + random.nextInt(Integer.MAX_VALUE) + "@test.com";
-      Exception exception = null;
+      Exception exceptionInFinally = null;
 
       try {
          OrgSettings newSettings = OrgSettings.builder()
@@ -328,21 +328,18 @@ public class AdminOrgApiLiveTest extends BaseVCloudDirectorApiLiveTest {
          assertTrue(equal(modified.getEmailSettings().getFromEmailAddress(), newFromEmailAddress),
                   String.format(OBJ_FIELD_UPDATABLE, "orgSettings", "emailSettings"));
 
-      } catch (Exception e) {
-         exception = e;
       } finally {
          try {
             OrgSettings restorableSettings = OrgSettings.builder().emailSettings(emailSettings).build();
 
             settings = adminOrgApi.editSettings(org.getId(), restorableSettings);
          } catch (Exception e) {
-            if (exception != null) {
-               logger.warn(e, "Error resetting settings; rethrowing original test exception...");
-               throw exception;
-            } else {
-               throw e;
-            }
+            exceptionInFinally = e;
+            logger.warn(e, "Error resetting settings");
          }
+      }
+      if (exceptionInFinally != null) {
+         throw exceptionInFinally;
       }
    }
 }

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminVdcApiLiveTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/features/admin/AdminVdcApiLiveTest.java
@@ -84,7 +84,7 @@ public class AdminVdcApiLiveTest extends BaseVCloudDirectorApiLiveTest {
    public void testEditVdc() throws Exception {
       String origName = lazyGetVdc().getName();
       String newName = name("a");
-      Exception exception = null;
+      Exception exceptionInFinally = null;
 
       AdminVdc vdc = AdminVdc.builder().name(newName).build();
 
@@ -97,21 +97,19 @@ public class AdminVdcApiLiveTest extends BaseVCloudDirectorApiLiveTest {
 
          // parent type
          Checks.checkAdminVdc(vdc);
-      } catch (Exception e) {
-         exception = e;
       } finally {
          try {
             AdminVdc restorableVdc = AdminVdc.builder().name(origName).build();
             Task task = vdcApi.edit(vdcUrn, restorableVdc);
             assertTaskSucceeds(task);
          } catch (Exception e) {
-            if (exception != null) {
-               logger.warn(e, "Error resetting adminVdc.name; rethrowing original test exception...");
-               throw exception;
-            } else {
-               throw e;
-            }
+            exceptionInFinally = e;
+            logger.warn(e, "Error resetting adminVdc.name");
          }
+      }
+      
+      if (exceptionInFinally != null) {
+         throw exceptionInFinally;
       }
    }
 
@@ -134,23 +132,20 @@ public class AdminVdcApiLiveTest extends BaseVCloudDirectorApiLiveTest {
    @Test(description = "DISABLE/ENABLE /admin/vdc/{id}", enabled = false)
    public void testDisableAndEnableVdc() throws Exception {
       // TODO Need to have a VDC that we're happy to remove!
-      Exception exception = null;
+      Exception exceptionInFinally = null;
 
       try {
          vdcApi.disable(vdcUrn);
-      } catch (Exception e) {
-         exception = e;
       } finally {
          try {
             vdcApi.enable(vdcUrn);
          } catch (Exception e) {
-            if (exception != null) {
-               logger.warn(e, "Error resetting adminVdc.name; rethrowing original test exception...");
-               throw exception;
-            } else {
-               throw e;
-            }
+            exceptionInFinally = e;
+            logger.warn(e, "Error resetting adminVdc.name");
          }
+      }
+      if (exceptionInFinally != null) {
+         throw exceptionInFinally;
       }
    }
 

--- a/src/test/java/org/jclouds/vcloud/director/v1_5/handlers/VcloudDirectorClientErrorRetryHandlerTest.java
+++ b/src/test/java/org/jclouds/vcloud/director/v1_5/handlers/VcloudDirectorClientErrorRetryHandlerTest.java
@@ -75,12 +75,12 @@ public class VcloudDirectorClientErrorRetryHandlerTest {
 
       String responsePayload = String.format(
             "<Error xmlns=\"http://www.vmware.com/vcloud/v1.5\"" 
-                  + " minorErrorCode=\"OPERATION_LIMITS_EXCEEDED\"" 
+                  + " minorErrorCode=\"%s\"" 
                   + " message=\"The maximum number of simultaneous operations for user &quot;myname&quot; on organization &quot;my-org&quot; has been reached.\"" 
-                  + " majorErrorCode=\"400\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                  + " majorErrorCode=\"%d\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
                   + " xsi:schemaLocation=\"http://www.vmware.com/vcloud/v1.5 http://acme.com/api/v1.5/schema/master.xsd\">"
                   + "</Error>",
-            errorCode);
+            errorCode, httpStatusCode);
 
       HttpResponse response = HttpResponse.builder().statusCode(httpStatusCode)
             .payload(Payloads.newStringPayload(responsePayload)).build();


### PR DESCRIPTION
See individual commits for details.

`TemplateBuilderImpl` is a copy, so I updated that by copy-pasting the v2.0.0 version, and then applying the changes (see comment at top of the class).

To make `mvn clean install` work, I needed to make lots of changes (because jclouds 2.0.0 uses google’s error-prone for additional validation checks). This required quite a few changes, including:
    
    - in pom.xml, change error-prone’s version to 2.0.15 and disable some checks that couldn’t be found.
    - in pom.xml, change “animal-sniffer” to check for java 1.7 compatibility, rather than 1.6
    - add generics (even where java can infer the right type)
    - remove unreachable code
    - disable VCloudDirectorComputeServiceAdapter.getAvailableVMsFromVAppTemplate, which was doing `computerName.equals(computerName)`.
      TODO: What is the right fix?!
    - Fields of enums must be final
    - imports of classes must not use “static”
    - remove @Provides from VCloudDirectorApi.getCurrentSession, because it’s not in a guice module.
    - Use “L” instead of “l” for longs
    - Add @Override everywhere
    - Pass charset to `new String(byte[])`
    - Make inner class `static` where possible
    - Don’t throw exception in finally block
    - Ensure `String.format(...)` has right number of args
